### PR TITLE
Bug/issue58 schema references

### DIFF
--- a/Manatee.Json.Tests/ClientTest.cs
+++ b/Manatee.Json.Tests/ClientTest.cs
@@ -365,8 +365,8 @@ namespace Manatee.Json.Tests
 		[DeploymentItem(@"Files\Issue58RefChild.json", "Files")]
 		public void Issue58_UriReferenceSchemaTest()
 		{
-			const string coreSchemaUri = "http://example.org/IssueRefCore.json";
-			const string childSchemaUri = "http://example.org/IssueRefChild.json";
+			const string coreSchemaUri = "http://example.org/Issue58RefCore.json";
+			const string childSchemaUri = "http://example.org/Issue58RefChild.json";
 
 			string coreSchemaPath = System.IO.Path.Combine(TestContext.TestDeploymentDir, @"Files\Issue58RefCore.json");
 			string childSchemaPath = System.IO.Path.Combine(TestContext.TestDeploymentDir, @"Files\Issue58RefChild.json");

--- a/Manatee.Json.Tests/Files/Issue58RefChild.json
+++ b/Manatee.Json.Tests/Files/Issue58RefChild.json
@@ -1,10 +1,10 @@
 ﻿{
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://example.org/IssueRefChild#",
+  "id": "http://example.org/Issue58RefChild#",
   "title": "Child Schema",
   "description": "",
   "properties": {
-    "myProperty": { "$ref": "IssueRefCore.json#/definitions/myProperty" }
+    "myProperty": { "$ref": "Issue58RefCore.json#/definitions/myProperty" }
   },
   "required": [ "myProperty" ]
 }

--- a/Manatee.Json.Tests/Files/Issue58RefCore.json
+++ b/Manatee.Json.Tests/Files/Issue58RefCore.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://example.org/IssueRefCore#",
+  "id": "http://example.org/Issue58RefCore#",
   "title": "Core Schema",
   "description": "",
   "definitions": {

--- a/Manatee.Json/Schema/JsonSchemaReference.cs
+++ b/Manatee.Json/Schema/JsonSchemaReference.cs
@@ -117,19 +117,19 @@ namespace Manatee.Json.Schema
 			var jValue = root;
 			if (!address.IsNullOrWhiteSpace())
 			{
+
+				Uri absolute;
+				if (DocumentPath != null && !Uri.TryCreate(address, UriKind.Absolute, out absolute))
+				{
+					DocumentPath = new Uri(DocumentPath.GetParentUri(), address);
+				}
+
 				Uri uri;
 				var search = JsonPathWith.Search("id");
 				var allIds = new Stack<string>(search.Evaluate(root ?? new JsonObject()).Select(jv => jv.String));
 				while (allIds.Any() && !Uri.TryCreate(address, UriKind.Absolute, out uri))
 				{
 					address = allIds.Pop() + address;
-				}
-
-				Uri absolute;
-
-				if (DocumentPath != null && !Uri.TryCreate(address, UriKind.Absolute, out absolute))
-				{
-					DocumentPath = new Uri(DocumentPath.GetParentUri(), address);
 				}
 
 				jValue = JsonSchemaRegistry.Get(DocumentPath?.ToString() ?? address).ToJson(null);


### PR DESCRIPTION
The problem appeared to be that the DocumentPath was created after the address had been modified with IDs. The fix was to create the DocumentPath as soon as the initial address was obtained.

I've also updated the test files to fix some references.