### PR TITLE
Parsing performance improvements (not for direct merge)

### DIFF
--- a/Manatee.Json/Internal/ObjectCache.cs
+++ b/Manatee.Json/Internal/ObjectCache.cs
@@ -5,79 +5,79 @@ using System.Threading;
 
 namespace Manatee.Json.Internal
 {
-    class ObjectCache<T> where T : class
-    {
-        private static readonly int CACHE_SIZE = Environment.ProcessorCount * 2;
+	class ObjectCache<T> where T : class
+	{
+		private static readonly int CACHE_SIZE = Environment.ProcessorCount * 2;
 
-        private T item = null;
-        private readonly T[] items = new T[CACHE_SIZE];
+		private T item = null;
+		private readonly T[] items = new T[CACHE_SIZE];
 
-        private readonly Func<T> builder;
+		private readonly Func<T> builder;
 
-        public ObjectCache(Func<T> builder)
-        {
-            this.builder = builder;
-        }
+		public ObjectCache(Func<T> builder)
+		{
+			this.builder = builder;
+		}
 
-        public T Acquire()
-        {
-            var instance = item;
-            if (instance == null || instance != Interlocked.CompareExchange(ref item, null, instance))
-            {
-                instance = AcquireSlow();
-            }
+		public T Acquire()
+		{
+			var instance = item;
+			if (instance == null || instance != Interlocked.CompareExchange(ref item, null, instance))
+			{
+				instance = AcquireSlow();
+			}
 
-            return instance;
-        }
+			return instance;
+		}
 
-        private T AcquireSlow()
-        {
-            for (int ii = 0; ii < items.Length; ++ii)
-            {
-                // Note that the initial read is optimistically not synchronized. That is intentional. 
-                // We will interlock only when we have a candidate. in a worst case we may miss some
-                // recently returned objects. Not a big deal.
-                var instance = items[ii];
-                if (instance != null)
-                {
-                    if (instance == Interlocked.CompareExchange(ref items[ii], null, instance))
-                    {
-                        return instance;
-                    }
-                }
-            }
+		private T AcquireSlow()
+		{
+			for (int ii = 0; ii < items.Length; ++ii)
+			{
+				// Note that the initial read is optimistically not synchronized. That is intentional. 
+				// We will interlock only when we have a candidate. in a worst case we may miss some
+				// recently returned objects. Not a big deal.
+				var instance = items[ii];
+				if (instance != null)
+				{
+					if (instance == Interlocked.CompareExchange(ref items[ii], null, instance))
+					{
+						return instance;
+					}
+				}
+			}
 
-            return builder();
-        }
+			return builder();
+		}
 
-        public void Release(T obj)
-        {
-            if (item == null)
-            {
-                // Intentionally not using interlocked here. 
-                // In a worst case scenario two objects may be stored into same slot.
-                // It is very unlikely to happen and will only mean that one of the objects will get collected.
-                item = obj;
-            }
-            else
-            {
-                ReleaseSlow(obj);
-            }
-        }
+		public void Release(T obj)
+		{
+			if (item == null)
+			{
+				// Intentionally not using interlocked here. 
+				// In a worst case scenario two objects may be stored into same slot.
+				// It is very unlikely to happen and will only mean that one of the objects will get collected.
+				item = obj;
+			}
+			else
+			{
+				ReleaseSlow(obj);
+			}
+		}
 
-        private void ReleaseSlow(T obj)
-        {
-            for (int ii = 0; ii < items.Length; ii++)
-            {
-                if (items[ii] == null)
-                {
-                    // Intentionally not using interlocked here. 
-                    // In a worst case scenario two objects may be stored into same slot.
-                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
-                    items[ii] = obj;
-                    break;
-                }
-            }
-        }
-    }
+		private void ReleaseSlow(T obj)
+		{
+			for (int ii = 0; ii < items.Length; ii++)
+			{
+				if (items[ii] == null)
+				{
+					// Intentionally not using interlocked here. 
+					// In a worst case scenario two objects may be stored into same slot.
+					// It is very unlikely to happen and will only mean that one of the objects will get collected.
+					items[ii] = obj;
+					break;
+				}
+			}
+		}
+	}
 }

--- a/Manatee.Json/Internal/ObjectCache.cs
+++ b/Manatee.Json/Internal/ObjectCache.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Manatee.Json.Internal
+{
+    class ObjectCache<T> where T : class
+    {
+        private static readonly int CACHE_SIZE = Environment.ProcessorCount * 2;
+
+        private T item = null;
+        private readonly T[] items = new T[CACHE_SIZE];
+
+        private readonly Func<T> builder;
+
+        public ObjectCache(Func<T> builder)
+        {
+            this.builder = builder;
+        }
+
+        public T Acquire()
+        {
+            var instance = item;
+            if (instance == null || instance != Interlocked.CompareExchange(ref item, null, instance))
+            {
+                instance = AcquireSlow();
+            }
+
+            return instance;
+        }
+
+        private T AcquireSlow()
+        {
+            for (int ii = 0; ii < items.Length; ++ii)
+            {
+                // Note that the initial read is optimistically not synchronized. That is intentional. 
+                // We will interlock only when we have a candidate. in a worst case we may miss some
+                // recently returned objects. Not a big deal.
+                var instance = items[ii];
+                if (instance != null)
+                {
+                    if (instance == Interlocked.CompareExchange(ref items[ii], null, instance))
+                    {
+                        return instance;
+                    }
+                }
+            }
+
+            return builder();
+        }
+
+        public void Release(T obj)
+        {
+            if (item == null)
+            {
+                // Intentionally not using interlocked here. 
+                // In a worst case scenario two objects may be stored into same slot.
+                // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                item = obj;
+            }
+            else
+            {
+                ReleaseSlow(obj);
+            }
+        }
+
+        private void ReleaseSlow(T obj)
+        {
+            for (int ii = 0; ii < items.Length; ii++)
+            {
+                if (items[ii] == null)
+                {
+                    // Intentionally not using interlocked here. 
+                    // In a worst case scenario two objects may be stored into same slot.
+                    // It is very unlikely to happen and will only mean that one of the objects will get collected.
+                    items[ii] = obj;
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/Manatee.Json/Internal/SmallBufferCache.cs
+++ b/Manatee.Json/Internal/SmallBufferCache.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Manatee.Json.Internal
+{
+    internal static class SmallBufferCache
+    {
+        static readonly int bufferSize = 8;
+
+        static readonly ObjectCache<char[]> cache = new ObjectCache<char[]>(() => new char[bufferSize]);
+
+        public static char[] Acquire(int size)
+        {
+            if (size <= bufferSize)
+                return cache.Acquire();
+
+            return new char[bufferSize];
+        }
+
+        public static void Release(char[] buffer)
+        {
+            if (buffer != null)
+            {
+                if (buffer.Length <= bufferSize)
+                    cache.Release(buffer);
+            }
+        }
+    }
+}

--- a/Manatee.Json/Internal/SmallBufferCache.cs
+++ b/Manatee.Json/Internal/SmallBufferCache.cs
@@ -4,27 +4,27 @@ using System.Text;
 
 namespace Manatee.Json.Internal
 {
-    internal static class SmallBufferCache
-    {
-        static readonly int bufferSize = 8;
+	internal static class SmallBufferCache
+	{
+		static readonly int bufferSize = 8;
 
-        static readonly ObjectCache<char[]> cache = new ObjectCache<char[]>(() => new char[bufferSize]);
+		static readonly ObjectCache<char[]> cache = new ObjectCache<char[]>(() => new char[bufferSize]);
 
-        public static char[] Acquire(int size)
-        {
-            if (size <= bufferSize)
-                return cache.Acquire();
+		public static char[] Acquire(int size)
+		{
+			if (size <= bufferSize)
+				return cache.Acquire();
 
-            return new char[bufferSize];
-        }
+			return new char[bufferSize];
+		}
 
-        public static void Release(char[] buffer)
-        {
-            if (buffer != null)
-            {
-                if (buffer.Length <= bufferSize)
-                    cache.Release(buffer);
-            }
-        }
-    }
+		public static void Release(char[] buffer)
+		{
+			if (buffer != null)
+			{
+				if (buffer.Length <= bufferSize)
+					cache.Release(buffer);
+			}
+		}
+	}
 }

--- a/Manatee.Json/Internal/StringBuilderCache.cs
+++ b/Manatee.Json/Internal/StringBuilderCache.cs
@@ -5,27 +5,27 @@ using System.Threading;
 
 namespace Manatee.Json.Internal
 {
-    internal static class StringBuilderCache
-    {
-        private static readonly ObjectCache<StringBuilder> cache = new ObjectCache<StringBuilder>(() => new StringBuilder());
+	internal static class StringBuilderCache
+	{
+		private static readonly ObjectCache<StringBuilder> cache = new ObjectCache<StringBuilder>(() => new StringBuilder());
 
-        public static StringBuilder Acquire() => cache.Acquire();
+		public static StringBuilder Acquire() => cache.Acquire();
 
-        public static void Release(StringBuilder sb)
-        {
-            // Don't hold onto string builders that are too large
-            if (sb.Capacity < 360)
-            {
-                sb.Clear();
-                cache.Release(sb);
-            }
-        }
+		public static void Release(StringBuilder sb)
+		{
+			// Don't hold onto string builders that are too large
+			if (sb.Capacity < 360)
+			{
+				sb.Clear();
+				cache.Release(sb);
+			}
+		}
 
-        public static string GetStringAndRelease(StringBuilder sb)
-        {
-            string result = sb.ToString();
-            Release(sb);
-            return result;
-        }
-    }
+		public static string GetStringAndRelease(StringBuilder sb)
+		{
+			string result = sb.ToString();
+			Release(sb);
+			return result;
+		}
+	}
 }

--- a/Manatee.Json/Internal/StringBuilderCache.cs
+++ b/Manatee.Json/Internal/StringBuilderCache.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+
+namespace Manatee.Json.Internal
+{
+    internal static class StringBuilderCache
+    {
+        private static readonly ObjectCache<StringBuilder> cache = new ObjectCache<StringBuilder>(() => new StringBuilder());
+
+        public static StringBuilder Acquire() => cache.Acquire();
+
+        public static void Release(StringBuilder sb)
+        {
+            // Don't hold onto string builders that are too large
+            if (sb.Capacity < 360)
+            {
+                sb.Clear();
+                cache.Release(sb);
+            }
+        }
+
+        public static string GetStringAndRelease(StringBuilder sb)
+        {
+            string result = sb.ToString();
+            Release(sb);
+            return result;
+        }
+    }
+}

--- a/Manatee.Json/Internal/StringExtensions.cs
+++ b/Manatee.Json/Internal/StringExtensions.cs
@@ -12,9 +12,9 @@ namespace Manatee.Json.Internal
 	internal static class StringExtensions
 	{
 		private static readonly IEnumerable<char> AvailableChars = Enumerable.Range(ushort.MinValue, ushort.MaxValue)
-		                                                                     .Select(n => (char) n)
-		                                                                     .Where(c => !char.IsControl(c))
-                                                                             .ToArray();
+																			 .Select(n => (char)n)
+																			 .Where(c => !char.IsControl(c))
+																			 .ToArray();
 		private static readonly Regex _generalEscapePattern = new Regex("%(?<Value>[0-9A-F]{2})", RegexOptions.IgnoreCase);
 
 		public static string EvaluateEscapeSequences(this string source, out string result)
@@ -128,10 +128,10 @@ namespace Manatee.Json.Internal
 		}
 		public static string SkipWhiteSpace(this string source, ref int index, int length, out char ch)
 		{
-            ch = default(char);
+			ch = default(char);
 			while (index < length)
 			{
-                ch = source[index];
+				ch = source[index];
 				if (!char.IsWhiteSpace(ch)) break;
 				index++;
 			}
@@ -146,12 +146,12 @@ namespace Manatee.Json.Internal
 		}
 		public static string SkipWhiteSpace(this TextReader stream, out char ch)
 		{
-			ch = (char) stream.Peek();
+			ch = (char)stream.Peek();
 			while (ch != -1)
 			{
 				if (!char.IsWhiteSpace(ch)) break;
 				stream.Read();
-				ch = (char) stream.Peek();
+				ch = (char)stream.Peek();
 			}
 
 			if (ch == -1)
@@ -162,49 +162,49 @@ namespace Manatee.Json.Internal
 
 			return null;
 		}
-        public static async Task<(string, char)> SkipWhiteSpaceAsync(this TextReader stream, char[] scratch)
-        {
-            System.Diagnostics.Debug.Assert(scratch.Length >= 1);
-            char ch;
-            ch = (char)stream.Peek();
-            while (ch != -1)
-            {
-                if (!char.IsWhiteSpace(ch)) break;
-                await stream.ReadAsync(scratch, 0, 1);
-                ch = (char)stream.Peek();
-            }
-            if (ch == -1)
-            {
-                ch = default(char);
-                return ("Unexpected end of input.", ch);
-            }
-            return (null, ch);
-        }
-        public static string UnescapePointer(this string reference)
+		public static async Task<(string, char)> SkipWhiteSpaceAsync(this TextReader stream, char[] scratch)
+		{
+			System.Diagnostics.Debug.Assert(scratch.Length >= 1);
+			char ch;
+			ch = (char)stream.Peek();
+			while (ch != -1)
+			{
+				if (!char.IsWhiteSpace(ch)) break;
+				await stream.ReadAsync(scratch, 0, 1);
+				ch = (char)stream.Peek();
+			}
+			if (ch == -1)
+			{
+				ch = default(char);
+				return ("Unexpected end of input.", ch);
+			}
+			return (null, ch);
+		}
+		public static string UnescapePointer(this string reference)
 		{
 			var unescaped = reference.Replace("~1", "/")
-			                         .Replace("~0", "~");
+									 .Replace("~0", "~");
 			var matches = _generalEscapePattern.Matches(unescaped);
 			foreach (Match match in matches)
 			{
 				var value = int.Parse(match.Groups["Value"].Value, NumberStyles.HexNumber);
-				var ch = (char) value;
+				var ch = (char)value;
 				unescaped = Regex.Replace(unescaped, match.Value, new string(ch, 1));
 			}
 			return unescaped;
 		}
-        public static Task<bool> TryRead(this TextReader stream, char[] buffer, int offset, int count)
-        {
-            return TryRead(stream, buffer, offset, count, CancellationToken.None);
-        }
-        public static async Task<bool> TryRead(this TextReader stream, char[] buffer, int offset, int count, CancellationToken token)
-        {
-            if (token.IsCancellationRequested)
-                return false;
+		public static Task<bool> TryRead(this TextReader stream, char[] buffer, int offset, int count)
+		{
+			return TryRead(stream, buffer, offset, count, CancellationToken.None);
+		}
+		public static async Task<bool> TryRead(this TextReader stream, char[] buffer, int offset, int count, CancellationToken token)
+		{
+			if (token.IsCancellationRequested)
+				return false;
 
-            var charsRead = await stream.ReadBlockAsync(buffer, offset, count);
+			var charsRead = await stream.ReadBlockAsync(buffer, offset, count);
 
-            return count == charsRead;
-        }
-    }
+			return count == charsRead;
+		}
+	}
 }

--- a/Manatee.Json/JsonValue.cs
+++ b/Manatee.Json/JsonValue.cs
@@ -46,8 +46,8 @@ namespace Manatee.Json
 			{
 				if (Type != JsonValueType.Boolean)
 					return !JsonOptions.ThrowOnIncorrectTypeAccess
-						       ? default(bool)
-						       : throw new JsonValueIncorrectTypeException(Type, JsonValueType.Boolean);
+							   ? default(bool)
+							   : throw new JsonValueIncorrectTypeException(Type, JsonValueType.Boolean);
 				return _boolValue;
 			}
 			private set
@@ -72,8 +72,8 @@ namespace Manatee.Json
 			{
 				if (Type != JsonValueType.String)
 					return !JsonOptions.ThrowOnIncorrectTypeAccess
-						       ? default(string)
-						       : throw new JsonValueIncorrectTypeException(Type, JsonValueType.String);
+							   ? default(string)
+							   : throw new JsonValueIncorrectTypeException(Type, JsonValueType.String);
 				return _stringValue;
 			}
 			private set
@@ -98,8 +98,8 @@ namespace Manatee.Json
 			{
 				if (Type != JsonValueType.Number)
 					return !JsonOptions.ThrowOnIncorrectTypeAccess
-						       ? default(double)
-						       : throw new JsonValueIncorrectTypeException(Type, JsonValueType.Number);
+							   ? default(double)
+							   : throw new JsonValueIncorrectTypeException(Type, JsonValueType.Number);
 				return _numberValue;
 			}
 			private set
@@ -124,8 +124,8 @@ namespace Manatee.Json
 			{
 				if (Type != JsonValueType.Object)
 					return !JsonOptions.ThrowOnIncorrectTypeAccess
-						       ? default(JsonObject)
-						       : throw new JsonValueIncorrectTypeException(Type, JsonValueType.Object);
+							   ? default(JsonObject)
+							   : throw new JsonValueIncorrectTypeException(Type, JsonValueType.Object);
 				return _objectValue;
 			}
 			private set
@@ -150,8 +150,8 @@ namespace Manatee.Json
 			{
 				if (Type != JsonValueType.Array)
 					return !JsonOptions.ThrowOnIncorrectTypeAccess
-						       ? default(JsonArray)
-						       : throw new JsonValueIncorrectTypeException(Type, JsonValueType.Array);
+							   ? default(JsonArray)
+							   : throw new JsonValueIncorrectTypeException(Type, JsonValueType.Array);
 				return _arrayValue;
 			}
 			private set

--- a/Manatee.Json/JsonValue.cs
+++ b/Manatee.Json/JsonValue.cs
@@ -358,12 +358,10 @@ namespace Manatee.Json
 		/// <exception cref="ArgumentNullException">Thrown if <paramref name="stream"/> is null.</exception>
 		/// <exception cref="ArgumentException">Thrown if <paramref name="stream"/> is at the end.</exception>
 		/// <exception cref="JsonSyntaxException">Thrown if <paramref name="stream"/> contains invalid JSON syntax.</exception>
-		public static JsonValue Parse(StreamReader stream)
+		public static JsonValue Parse(TextReader stream)
 		{
 			if (stream == null)
 				throw new ArgumentNullException(nameof(stream));
-			if (stream.EndOfStream)
-				throw new ArgumentException("Source string contains no data.");
 			return JsonParser.Parse(stream);
 		}
 		/// <summary>
@@ -374,12 +372,10 @@ namespace Manatee.Json
 		/// <exception cref="ArgumentNullException">Thrown if <paramref name="stream"/> is null.</exception>
 		/// <exception cref="ArgumentException">Thrown if <paramref name="stream"/> is at the end.</exception>
 		/// <exception cref="JsonSyntaxException">Thrown if <paramref name="stream"/> contains invalid JSON syntax.</exception>
-		public static Task<JsonValue> ParseAsync(StreamReader stream)
+		public static Task<JsonValue> ParseAsync(TextReader stream)
 		{
 			if (stream == null)
 				throw new ArgumentNullException(nameof(stream));
-			if (stream.EndOfStream)
-				throw new ArgumentException("Source string contains no data.");
 			return JsonParser.ParseAsync(stream);
 		}
 

--- a/Manatee.Json/Parsing/ArrayParser.cs
+++ b/Manatee.Json/Parsing/ArrayParser.cs
@@ -45,11 +45,11 @@ namespace Manatee.Json.Parsing
 			}
 			return null;
 		}
-		public string TryParse(StreamReader stream, out JsonValue value)
+		public string TryParse(TextReader stream, out JsonValue value)
 		{
 			var array = new JsonArray();
 			value = array;
-			while (!stream.EndOfStream)
+			while (stream.Peek() != -1)
 			{
 				stream.Read(); // waste the '[' or ','
 				var message = stream.SkipWhiteSpace(out char c);
@@ -78,40 +78,70 @@ namespace Manatee.Json.Parsing
 			}
 			return null;
 		}
-		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(StreamReader stream, CancellationToken token)
+		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
+            var scratch = SmallBufferCache.Acquire(1);
 			var array = new JsonArray();
-			while (!stream.EndOfStream)
+
+            char c;
+            string errorMessage = null;
+			while (stream.Peek() != -1)
 			{
-				if (token.IsCancellationRequested)
-					return ("Parsing incomplete. The task was cancelled.", null);
-				await stream.TryRead(); // waste the '[' or ','
-				var (message, c) = await stream.SkipWhiteSpaceAsync();
-				if (message != null) return (message, array);
-				// check for empty array
-				if (c == ']')
-					if (array.Count == 0)
-					{
-						await stream.TryRead(); // waste the ']'
-						break;
-					}
-					else return ("Expected value.", null);
+                if (token.IsCancellationRequested)
+                {
+                    errorMessage = "Parsing incomplete. The task was cancelled.";
+                    break;
+                }
+
+				await stream.TryRead(scratch, 0, 1); // waste the '[' or ','
+				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
+                if (errorMessage != null)
+                    break;
+
+                // check for empty array
+                if (c == ']')
+                {
+                    if (array.Count == 0)
+                    {
+                        await stream.TryRead(scratch, 0, 1); // waste the ']'
+                        break;
+                    }
+                    else
+                    {
+                        errorMessage = "Expected value.";
+                        break;
+                    }
+                }
+
 				// get value
 				JsonValue item;
-				(message, item) = await JsonParser.TryParseAsync(stream, token);
+				(errorMessage, item) = await JsonParser.TryParseAsync(stream, token);
 				array.Add(item);
-				if (message != null) return (message, null);
-				(message, c) = await stream.SkipWhiteSpaceAsync();
-				if (message != null) return (message, null);
+                if (errorMessage != null)
+                    break;
+
+				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
+                if (errorMessage != null)
+                    break;
+
 				// check for end or separator
 				if (c == ']')
 				{
-					await stream.TryRead(); // waste the ']'
+					await stream.TryRead(scratch, 0, 1); // waste the ']'
 					break;
 				}
-				if (c != ',') return ("Expected ','.", null);
+
+                if (c != ',')
+                {
+                    errorMessage = "Expected ','.";
+                    break;
+                }
 			}
-			return (null, array);
+
+            JsonValue value = errorMessage == null ? array : null;
+
+            SmallBufferCache.Release(scratch);
+            return (errorMessage, value);
 		}
 	}
 }

--- a/Manatee.Json/Parsing/ArrayParser.cs
+++ b/Manatee.Json/Parsing/ArrayParser.cs
@@ -80,49 +80,49 @@ namespace Manatee.Json.Parsing
 		}
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-            var scratch = SmallBufferCache.Acquire(1);
+			var scratch = SmallBufferCache.Acquire(1);
 			var array = new JsonArray();
 
-            char c;
-            string errorMessage = null;
+			char c;
+			string errorMessage = null;
 			while (stream.Peek() != -1)
 			{
-                if (token.IsCancellationRequested)
-                {
-                    errorMessage = "Parsing incomplete. The task was cancelled.";
-                    break;
-                }
+				if (token.IsCancellationRequested)
+				{
+					errorMessage = "Parsing incomplete. The task was cancelled.";
+					break;
+				}
 
 				await stream.TryRead(scratch, 0, 1); // waste the '[' or ','
 				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
-                if (errorMessage != null)
-                    break;
+				if (errorMessage != null)
+					break;
 
-                // check for empty array
-                if (c == ']')
-                {
-                    if (array.Count == 0)
-                    {
-                        await stream.TryRead(scratch, 0, 1); // waste the ']'
-                        break;
-                    }
-                    else
-                    {
-                        errorMessage = "Expected value.";
-                        break;
-                    }
-                }
+				// check for empty array
+				if (c == ']')
+				{
+					if (array.Count == 0)
+					{
+						await stream.TryRead(scratch, 0, 1); // waste the ']'
+						break;
+					}
+					else
+					{
+						errorMessage = "Expected value.";
+						break;
+					}
+				}
 
 				// get value
 				JsonValue item;
 				(errorMessage, item) = await JsonParser.TryParseAsync(stream, token);
 				array.Add(item);
-                if (errorMessage != null)
-                    break;
+				if (errorMessage != null)
+					break;
 
 				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
-                if (errorMessage != null)
-                    break;
+				if (errorMessage != null)
+					break;
 
 				// check for end or separator
 				if (c == ']')
@@ -131,17 +131,17 @@ namespace Manatee.Json.Parsing
 					break;
 				}
 
-                if (c != ',')
-                {
-                    errorMessage = "Expected ','.";
-                    break;
-                }
+				if (c != ',')
+				{
+					errorMessage = "Expected ','.";
+					break;
+				}
 			}
 
-            JsonValue value = errorMessage == null ? array : null;
+			JsonValue value = errorMessage == null ? array : null;
 
-            SmallBufferCache.Release(scratch);
-            return (errorMessage, value);
+			SmallBufferCache.Release(scratch);
+			return (errorMessage, value);
 		}
 	}
 }

--- a/Manatee.Json/Parsing/BoolParser.cs
+++ b/Manatee.Json/Parsing/BoolParser.cs
@@ -8,102 +8,165 @@ namespace Manatee.Json.Parsing
 {
 	internal class BoolParser : IJsonParser
 	{
-		public bool Handles(char c)
+        static readonly string UnexpectedEndOfInput = "Unexpected end of input.";
+
+        public bool Handles(char c)
 		{
-			return c.In('t', 'T', 'f', 'F');
+            switch (c)
+            {
+                case 't': case 'T':
+                case 'f': case 'F':
+                    return true;
+            }
+            return false;
 		}
+
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
+            value = null;
+            
+			if (source[index] == 't' || source[index] == 'T')
+			{
+                if (index + 4 >= source.Length)
+                    return UnexpectedEndOfInput;
+
+                if (source.IndexOf("true", index, 4, StringComparison.OrdinalIgnoreCase) != index)
+                {
+                    return $"Value not recognized: '{source.Substring(index, 4)}'";
+                }
+
+                index += 4;
+                value = true;
+			}
+			else
+			{
+                if (index + 5 >= source.Length)
+                    return UnexpectedEndOfInput;
+
+                if (source.IndexOf("false", index, 5, StringComparison.OrdinalIgnoreCase) != index)
+                {
+                    return $"Value not recognized: '{source.Substring(index, 5)}'";
+                }
+
+                index += 5;
+                value = false;
+            }
+
+            return null;
+		}
+
+		public string TryParse(TextReader stream, out JsonValue value)
+		{
+            value = null;
+
 			char[] buffer;
 			int count;
-			if (source[index].In('t', 'T'))
+			var current = (char) stream.Peek();
+			if (current == 't' || current == 'T')
 			{
-				buffer = new char[4];
 				count = 4;
 			}
 			else
 			{
-				buffer = new char[5];
 				count = 5;
 			}
-			count = Math.Min(count, source.Length - index);
-			for (var i = 0; i < count; i++)
-			{
-				buffer[i] = source[index + i];
-			}
-			var result = new string(buffer).ToLower();
-			if (result == "true")
-			{
-				index += 4;
-				value = true;
-				return null;
-			}
-			if (result == "false")
-			{
-				index += 5;
-				value = false;
-				return null;
-			}
-			value = null;
-			return $"Value not recognized: '{result}'";
+
+            buffer = SmallBufferCache.Acquire(count);
+            var charsRead = stream.ReadBlock(buffer, 0, count);
+            if (charsRead != count)
+            {
+                SmallBufferCache.Release(buffer);
+                return UnexpectedEndOfInput;
+            }
+
+            string errorMessage = null;
+            if (count == 4)
+            {
+                if ((buffer[0] == 't' || buffer[0] == 'T')
+                 && (buffer[1] == 'r' || buffer[1] == 'R')
+                 && (buffer[2] == 'u' || buffer[2] == 'U')
+                 && (buffer[3] == 'e' || buffer[3] == 'E'))
+                {
+                    value = true;
+                }
+                else
+                {
+                    errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
+                }
+            }
+            else
+            {
+                if ((buffer[0] == 'f' || buffer[0] == 'F')
+                 && (buffer[1] == 'a' || buffer[1] == 'A')
+                 && (buffer[2] == 'l' || buffer[2] == 'L')
+                 && (buffer[3] == 's' || buffer[3] == 'S')
+                 && (buffer[4] == 'e' || buffer[4] == 'E'))
+                {
+                    value = false;
+                }
+                else
+                {
+                    errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
+                }
+            }
+
+            SmallBufferCache.Release(buffer);
+			return errorMessage;
 		}
-		public string TryParse(StreamReader stream, out JsonValue value)
+
+		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			char[] buffer;
-			int count;
-			var current = (char) stream.Read();
-			if (current.In('t', 'T'))
-			{
-				buffer = new char[4];
-				count = 4;
-			}
-			else
-			{
-				buffer = new char[5];
-				count = 5;
-			}
-			buffer[0] = current;
-			for (int i = 1; i < count && !stream.EndOfStream; i++)
-			{
-				buffer[i] = (char) stream.Read();
-			}
-			if (buffer[count - 1] == (char) 0 && stream.EndOfStream)
-			{
-				value = null;
-				return "Unexpected end of input.";
-			}
-			var result = new string(buffer).ToLower();
-			if (result == "true")
-			{
-				value = true;
-				return null;
-			}
-			if (result == "false")
-			{
-				value = false;
-				return null;
-			}
-			value = null;
-			return $"Value not recognized: '{result}'";
-		}
-		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(StreamReader stream, CancellationToken token)
-		{
-			var buffer = new char[4];
+			var buffer = SmallBufferCache.Acquire(5);
 			var count = await stream.ReadAsync(buffer, 0, 4);
-			if (count < 4)
-				return ("Unexpected end of input.", null);
-			var result = new string(buffer).ToLower();
-			if (result == "true")
-				return (null, true);
-			if (result != "fals")
-				return ($"Value not recognized: '{result}'.", null);
-			var readResult = await stream.TryRead();
-			if (!readResult.success)
-				return ("Unexpected end of input.", null);
-			result += readResult.c;
-			if (result == "false")
-				return (null, false);
-			return ($"Value not recognized: '{result}'.", null);
+            if (count < 4)
+            {
+                SmallBufferCache.Release(buffer);
+                return ("Unexpected end of input.", null);
+            }
+
+            if (token.IsCancellationRequested)
+            {
+                SmallBufferCache.Release(buffer);
+                return ("Parsing incomplete. The task was cancelled.", null);
+            }
+
+            JsonValue value = null;
+            string errorMessage = null;
+            if ((buffer[0] == 't' || buffer[0] == 'T')
+             && (buffer[1] == 'r' || buffer[1] == 'R')
+             && (buffer[2] == 'u' || buffer[2] == 'U')
+             && (buffer[3] == 'e' || buffer[3] == 'E'))
+            {
+                value = true;
+            }
+            else if ((buffer[0] == 'f' || buffer[0] == 'F')
+                  && (buffer[1] == 'a' || buffer[1] == 'A')
+                  && (buffer[2] == 'l' || buffer[2] == 'L')
+                  && (buffer[3] == 's' || buffer[3] == 'S'))
+            {
+                if (await stream.TryRead(buffer, 4, 1))
+                {
+                    if (buffer[4] == 'e' || buffer[4] == 'E')
+                    {
+                        value = false;
+                    }
+                    else
+                    {
+                        errorMessage = $"Value not recognized: 'fals{buffer[4]}'.";
+                    }
+                }
+                else
+                {
+                    errorMessage = "Unexpected end of input.";
+                }
+            }
+            else
+            {
+                errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
+            }
+
+            SmallBufferCache.Release(buffer);
+			return (errorMessage, value);
 		}
 	}
 }

--- a/Manatee.Json/Parsing/BoolParser.cs
+++ b/Manatee.Json/Parsing/BoolParser.cs
@@ -8,60 +8,62 @@ namespace Manatee.Json.Parsing
 {
 	internal class BoolParser : IJsonParser
 	{
-        static readonly string UnexpectedEndOfInput = "Unexpected end of input.";
+		static readonly string UnexpectedEndOfInput = "Unexpected end of input.";
 
-        public bool Handles(char c)
+		public bool Handles(char c)
 		{
-            switch (c)
-            {
-                case 't': case 'T':
-                case 'f': case 'F':
-                    return true;
-            }
-            return false;
+			switch (c)
+			{
+				case 't':
+				case 'T':
+				case 'f':
+				case 'F':
+					return true;
+			}
+			return false;
 		}
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-            value = null;
-            
+			value = null;
+
 			if (source[index] == 't' || source[index] == 'T')
 			{
-                if (index + 4 >= source.Length)
-                    return UnexpectedEndOfInput;
+				if (index + 4 >= source.Length)
+					return UnexpectedEndOfInput;
 
-                if (source.IndexOf("true", index, 4, StringComparison.OrdinalIgnoreCase) != index)
-                {
-                    return $"Value not recognized: '{source.Substring(index, 4)}'";
-                }
+				if (source.IndexOf("true", index, 4, StringComparison.OrdinalIgnoreCase) != index)
+				{
+					return $"Value not recognized: '{source.Substring(index, 4)}'";
+				}
 
-                index += 4;
-                value = true;
+				index += 4;
+				value = true;
 			}
 			else
 			{
-                if (index + 5 >= source.Length)
-                    return UnexpectedEndOfInput;
+				if (index + 5 >= source.Length)
+					return UnexpectedEndOfInput;
 
-                if (source.IndexOf("false", index, 5, StringComparison.OrdinalIgnoreCase) != index)
-                {
-                    return $"Value not recognized: '{source.Substring(index, 5)}'";
-                }
+				if (source.IndexOf("false", index, 5, StringComparison.OrdinalIgnoreCase) != index)
+				{
+					return $"Value not recognized: '{source.Substring(index, 5)}'";
+				}
 
-                index += 5;
-                value = false;
-            }
+				index += 5;
+				value = false;
+			}
 
-            return null;
+			return null;
 		}
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
-            value = null;
+			value = null;
 
 			char[] buffer;
 			int count;
-			var current = (char) stream.Peek();
+			var current = (char)stream.Peek();
 			if (current == 't' || current == 'T')
 			{
 				count = 4;
@@ -71,46 +73,46 @@ namespace Manatee.Json.Parsing
 				count = 5;
 			}
 
-            buffer = SmallBufferCache.Acquire(count);
-            var charsRead = stream.ReadBlock(buffer, 0, count);
-            if (charsRead != count)
-            {
-                SmallBufferCache.Release(buffer);
-                return UnexpectedEndOfInput;
-            }
+			buffer = SmallBufferCache.Acquire(count);
+			var charsRead = stream.ReadBlock(buffer, 0, count);
+			if (charsRead != count)
+			{
+				SmallBufferCache.Release(buffer);
+				return UnexpectedEndOfInput;
+			}
 
-            string errorMessage = null;
-            if (count == 4)
-            {
-                if ((buffer[0] == 't' || buffer[0] == 'T')
-                 && (buffer[1] == 'r' || buffer[1] == 'R')
-                 && (buffer[2] == 'u' || buffer[2] == 'U')
-                 && (buffer[3] == 'e' || buffer[3] == 'E'))
-                {
-                    value = true;
-                }
-                else
-                {
-                    errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
-                }
-            }
-            else
-            {
-                if ((buffer[0] == 'f' || buffer[0] == 'F')
-                 && (buffer[1] == 'a' || buffer[1] == 'A')
-                 && (buffer[2] == 'l' || buffer[2] == 'L')
-                 && (buffer[3] == 's' || buffer[3] == 'S')
-                 && (buffer[4] == 'e' || buffer[4] == 'E'))
-                {
-                    value = false;
-                }
-                else
-                {
-                    errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
-                }
-            }
+			string errorMessage = null;
+			if (count == 4)
+			{
+				if ((buffer[0] == 't' || buffer[0] == 'T')
+				 && (buffer[1] == 'r' || buffer[1] == 'R')
+				 && (buffer[2] == 'u' || buffer[2] == 'U')
+				 && (buffer[3] == 'e' || buffer[3] == 'E'))
+				{
+					value = true;
+				}
+				else
+				{
+					errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
+				}
+			}
+			else
+			{
+				if ((buffer[0] == 'f' || buffer[0] == 'F')
+				 && (buffer[1] == 'a' || buffer[1] == 'A')
+				 && (buffer[2] == 'l' || buffer[2] == 'L')
+				 && (buffer[3] == 's' || buffer[3] == 'S')
+				 && (buffer[4] == 'e' || buffer[4] == 'E'))
+				{
+					value = false;
+				}
+				else
+				{
+					errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
+				}
+			}
 
-            SmallBufferCache.Release(buffer);
+			SmallBufferCache.Release(buffer);
 			return errorMessage;
 		}
 
@@ -118,54 +120,54 @@ namespace Manatee.Json.Parsing
 		{
 			var buffer = SmallBufferCache.Acquire(5);
 			var count = await stream.ReadAsync(buffer, 0, 4);
-            if (count < 4)
-            {
-                SmallBufferCache.Release(buffer);
-                return ("Unexpected end of input.", null);
-            }
+			if (count < 4)
+			{
+				SmallBufferCache.Release(buffer);
+				return ("Unexpected end of input.", null);
+			}
 
-            if (token.IsCancellationRequested)
-            {
-                SmallBufferCache.Release(buffer);
-                return ("Parsing incomplete. The task was cancelled.", null);
-            }
+			if (token.IsCancellationRequested)
+			{
+				SmallBufferCache.Release(buffer);
+				return ("Parsing incomplete. The task was cancelled.", null);
+			}
 
-            JsonValue value = null;
-            string errorMessage = null;
-            if ((buffer[0] == 't' || buffer[0] == 'T')
-             && (buffer[1] == 'r' || buffer[1] == 'R')
-             && (buffer[2] == 'u' || buffer[2] == 'U')
-             && (buffer[3] == 'e' || buffer[3] == 'E'))
-            {
-                value = true;
-            }
-            else if ((buffer[0] == 'f' || buffer[0] == 'F')
-                  && (buffer[1] == 'a' || buffer[1] == 'A')
-                  && (buffer[2] == 'l' || buffer[2] == 'L')
-                  && (buffer[3] == 's' || buffer[3] == 'S'))
-            {
-                if (await stream.TryRead(buffer, 4, 1))
-                {
-                    if (buffer[4] == 'e' || buffer[4] == 'E')
-                    {
-                        value = false;
-                    }
-                    else
-                    {
-                        errorMessage = $"Value not recognized: 'fals{buffer[4]}'.";
-                    }
-                }
-                else
-                {
-                    errorMessage = "Unexpected end of input.";
-                }
-            }
-            else
-            {
-                errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
-            }
+			JsonValue value = null;
+			string errorMessage = null;
+			if ((buffer[0] == 't' || buffer[0] == 'T')
+			 && (buffer[1] == 'r' || buffer[1] == 'R')
+			 && (buffer[2] == 'u' || buffer[2] == 'U')
+			 && (buffer[3] == 'e' || buffer[3] == 'E'))
+			{
+				value = true;
+			}
+			else if ((buffer[0] == 'f' || buffer[0] == 'F')
+				  && (buffer[1] == 'a' || buffer[1] == 'A')
+				  && (buffer[2] == 'l' || buffer[2] == 'L')
+				  && (buffer[3] == 's' || buffer[3] == 'S'))
+			{
+				if (await stream.TryRead(buffer, 4, 1))
+				{
+					if (buffer[4] == 'e' || buffer[4] == 'E')
+					{
+						value = false;
+					}
+					else
+					{
+						errorMessage = $"Value not recognized: 'fals{buffer[4]}'.";
+					}
+				}
+				else
+				{
+					errorMessage = "Unexpected end of input.";
+				}
+			}
+			else
+			{
+				errorMessage = $"Value not recognized: '{new string(buffer, 0, count)}'.";
+			}
 
-            SmallBufferCache.Release(buffer);
+			SmallBufferCache.Release(buffer);
 			return (errorMessage, value);
 		}
 	}

--- a/Manatee.Json/Parsing/IJsonParser.cs
+++ b/Manatee.Json/Parsing/IJsonParser.cs
@@ -9,7 +9,7 @@ namespace Manatee.Json.Parsing
 		bool Handles(char c);
 		// returns error message, if any.  Null return implies success.
 		string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars);
-		string TryParse(StreamReader stream, out JsonValue value);
-		Task<(string errorMessage, JsonValue value)> TryParseAsync(StreamReader stream, CancellationToken token);
+		string TryParse(TextReader stream, out JsonValue value);
+		Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token);
 	}
 }

--- a/Manatee.Json/Parsing/JsonParser.cs
+++ b/Manatee.Json/Parsing/JsonParser.cs
@@ -16,10 +16,10 @@ namespace Manatee.Json.Parsing
 		static JsonParser()
 		{
 			Parsers = typeof(JsonParser).GetTypeInfo().Assembly.DefinedTypes
-			                            .Where(t => typeof(IJsonParser).GetTypeInfo().IsAssignableFrom(t) && t.IsClass)
-			                            .Select(ti => Activator.CreateInstance(ti.AsType()))
-			                            .Cast<IJsonParser>()
-			                            .ToList();
+										.Where(t => typeof(IJsonParser).GetTypeInfo().IsAssignableFrom(t) && t.IsClass)
+										.Select(ti => Activator.CreateInstance(ti.AsType()))
+										.Cast<IJsonParser>()
+										.ToList();
 		}
 
 		public static JsonValue Parse(string source)
@@ -54,11 +54,11 @@ namespace Manatee.Json.Parsing
 				return errorMessage;
 			}
 
-            foreach (var parser in Parsers)
-            {
-                if (parser.Handles(c))
-                    return parser.TryParse(source, ref index, out value, allowExtraChars);
-            }
+			foreach (var parser in Parsers)
+			{
+				if (parser.Handles(c))
+					return parser.TryParse(source, ref index, out value, allowExtraChars);
+			}
 
 			value = null;
 			return "Cannot determine type.";
@@ -72,13 +72,13 @@ namespace Manatee.Json.Parsing
 				return errorMessage;
 			}
 
-            foreach (var parser in Parsers)
-            {
-                if (parser.Handles(c))
-                    return parser.TryParse(stream, out value);
-            }
+			foreach (var parser in Parsers)
+			{
+				if (parser.Handles(c))
+					return parser.TryParse(stream, out value);
+			}
 
-            value = null;
+			value = null;
 			return "Cannot determine type.";
 		}
 		public static async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
@@ -89,13 +89,13 @@ namespace Manatee.Json.Parsing
 				return (errorMessage, null);
 			}
 
-            foreach (var parser in Parsers)
-            {
-                if (parser.Handles(c))
-                    return await parser.TryParseAsync(stream, token);
-            }
+			foreach (var parser in Parsers)
+			{
+				if (parser.Handles(c))
+					return await parser.TryParseAsync(stream, token);
+			}
 
-    		return ("Cannot determine type.", null);
+			return ("Cannot determine type.", null);
 		}
 	}
 }

--- a/Manatee.Json/Parsing/JsonParser.cs
+++ b/Manatee.Json/Parsing/JsonParser.cs
@@ -30,14 +30,14 @@ namespace Manatee.Json.Parsing
 				throw new JsonSyntaxException(errorMessage, value);
 			return value;
 		}
-		public static JsonValue Parse(StreamReader stream)
+		public static JsonValue Parse(TextReader stream)
 		{
 			var errorMessage = Parse(stream, out JsonValue value);
 			if (errorMessage != null)
 				throw new JsonSyntaxException(errorMessage, value);
 			return value;
 		}
-		public static async Task<JsonValue> ParseAsync(StreamReader stream, CancellationToken token = default(CancellationToken))
+		public static async Task<JsonValue> ParseAsync(TextReader stream, CancellationToken token = default(CancellationToken))
 		{
 			var (errorMessage, value) = await TryParseAsync(stream, token);
 			if (errorMessage != null)
@@ -62,7 +62,7 @@ namespace Manatee.Json.Parsing
 			errorMessage = parser.TryParse(source, ref index, out value, allowExtraChars);
 			return errorMessage;
 		}
-		public static string Parse(StreamReader stream, out JsonValue value)
+		public static string Parse(TextReader stream, out JsonValue value)
 		{
 			var errorMessage = stream.SkipWhiteSpace(out char c);
 			if (errorMessage != null)
@@ -79,7 +79,7 @@ namespace Manatee.Json.Parsing
 			errorMessage = parser.TryParse(stream, out value);
 			return errorMessage;
 		}
-		public static async Task<(string errorMessage, JsonValue value)> TryParseAsync(StreamReader stream, CancellationToken token)
+		public static async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
 			var errorMessage = stream.SkipWhiteSpace(out char c);
 			if (errorMessage != null)

--- a/Manatee.Json/Parsing/JsonParser.cs
+++ b/Manatee.Json/Parsing/JsonParser.cs
@@ -53,14 +53,15 @@ namespace Manatee.Json.Parsing
 				value = null;
 				return errorMessage;
 			}
-			var parser = Parsers.FirstOrDefault(p => p.Handles(c));
-			if (parser == null)
-			{
-				value = null;
-				return "Cannot determine type.";
-			}
-			errorMessage = parser.TryParse(source, ref index, out value, allowExtraChars);
-			return errorMessage;
+
+            foreach (var parser in Parsers)
+            {
+                if (parser.Handles(c))
+                    return parser.TryParse(source, ref index, out value, allowExtraChars);
+            }
+
+			value = null;
+			return "Cannot determine type.";
 		}
 		public static string Parse(TextReader stream, out JsonValue value)
 		{
@@ -70,14 +71,15 @@ namespace Manatee.Json.Parsing
 				value = null;
 				return errorMessage;
 			}
-			var parser = Parsers.FirstOrDefault(p => p.Handles(c));
-			if (parser == null)
-			{
-				value = null;
-				return "Cannot determine type.";
-			}
-			errorMessage = parser.TryParse(stream, out value);
-			return errorMessage;
+
+            foreach (var parser in Parsers)
+            {
+                if (parser.Handles(c))
+                    return parser.TryParse(stream, out value);
+            }
+
+            value = null;
+			return "Cannot determine type.";
 		}
 		public static async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
@@ -86,12 +88,14 @@ namespace Manatee.Json.Parsing
 			{
 				return (errorMessage, null);
 			}
-			var parser = Parsers.FirstOrDefault(p => p.Handles(c));
-			if (parser == null)
-			{
-				return ("Cannot determine type.", null);
-			}
-			return await parser.TryParseAsync(stream, token);
+
+            foreach (var parser in Parsers)
+            {
+                if (parser.Handles(c))
+                    return await parser.TryParseAsync(stream, token);
+            }
+
+    		return ("Cannot determine type.", null);
 		}
 	}
 }

--- a/Manatee.Json/Parsing/NullParser.cs
+++ b/Manatee.Json/Parsing/NullParser.cs
@@ -7,58 +7,79 @@ namespace Manatee.Json.Parsing
 {
 	internal class NullParser : IJsonParser
 	{
-		public bool Handles(char c)
+        static readonly string UnexpectedEndOfInput = "Unexpected end of input.";
+
+        public bool Handles(char c)
 		{
-			return c.In('n', 'N');
+            return c == 'n' || c == 'N';
 		}
+
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			var buffer = new char[4];
-			for (var i = 0; i < 4 && index + i < source.Length; i++)
-			{
-				buffer[i] = source[index + i];
-			}
-			var result = new string(buffer).ToLower();
-			if (result != "null")
-			{
-				value = null;
-				return $"Value not recognized: '{result}'.";
-			}
+            value = null;
+
+            if (index + 4 >= source.Length)
+                return UnexpectedEndOfInput;
+
+            if (source.IndexOf("null", index, 4, System.StringComparison.OrdinalIgnoreCase) != index)
+                return $"Value not recognized: {source.Substring(index, 4)}";
+            
 			index += 4;
 			value = JsonValue.Null;
 			return null;
 		}
-		public string TryParse(StreamReader stream, out JsonValue value)
+
+		public string TryParse(TextReader stream, out JsonValue value)
 		{
-			var buffer = new char[4];
-			for (var i = 0; i < 4 && !stream.EndOfStream; i++)
-			{
-				buffer[i] = (char) stream.Read();
-			}
-			if (buffer[3] == (char) 0 && stream.EndOfStream)
-			{
-				value = null;
-				return "Unexpected end of input.";
-			}
-			var result = new string(buffer).ToLower();
-			if (result != "null")
-			{
-				value = null;
-				return $"Value not recognized: '{result}'.";
-			}
-			value = JsonValue.Null;
-			return null;
+            value = null;
+
+            var buffer = SmallBufferCache.Acquire(4);
+            var charsRead = stream.ReadBlock(buffer, 0, 4);
+            if (charsRead != 4)
+            {
+                SmallBufferCache.Release(buffer);
+                return UnexpectedEndOfInput;
+            }
+
+            string errorMessage = null;
+            if ((buffer[0] == 'n' || buffer[0] == 'N')
+             && (buffer[1] == 'u' || buffer[1] == 'U')
+             && (buffer[2] == 'l' || buffer[2] == 'L')
+             && (buffer[3] == 'l' || buffer[3] == 'L'))
+            {
+                value = JsonValue.Null;
+            }
+            else
+            {
+                errorMessage = $"Value not recognized: '{new string(buffer)}'.";
+            }
+
+            SmallBufferCache.Release(buffer);
+            return errorMessage;
 		}
-		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(StreamReader stream, CancellationToken token)
+		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			var buffer = new char[4];
-			var count = await stream.ReadAsync(buffer, 0, 4);
-			if (count < 4)
-				return ("Unexpected end of input.", null);
-			var result = new string(buffer).ToLower();
-			if (result != "null")
-				return ($"Value not recognized: '{result}'.", null);
-			return (null, JsonValue.Null);
+			var buffer = SmallBufferCache.Acquire(4);
+			var count = await stream.ReadBlockAsync(buffer, 0, 4);
+            if (count < 4)
+            {
+                SmallBufferCache.Release(buffer);
+                return ("Unexpected end of input.", null);
+            }
+
+            var value = JsonValue.Null;
+            string errorMessage = null;
+            if ((buffer[0] != 'n' && buffer[0] != 'N')
+             && (buffer[1] != 'u' && buffer[1] != 'U')
+             && (buffer[2] != 'l' && buffer[2] != 'L')
+             && (buffer[3] != 'l' && buffer[3] != 'L'))
+            {
+                value = null;
+                errorMessage = $"Value not recognized: '{value}'.";
+            }
+
+            SmallBufferCache.Release(buffer);
+            return (errorMessage, value);
 		}
 	}
 }

--- a/Manatee.Json/Parsing/NullParser.cs
+++ b/Manatee.Json/Parsing/NullParser.cs
@@ -7,23 +7,23 @@ namespace Manatee.Json.Parsing
 {
 	internal class NullParser : IJsonParser
 	{
-        static readonly string UnexpectedEndOfInput = "Unexpected end of input.";
+		static readonly string UnexpectedEndOfInput = "Unexpected end of input.";
 
-        public bool Handles(char c)
+		public bool Handles(char c)
 		{
-            return c == 'n' || c == 'N';
+			return c == 'n' || c == 'N';
 		}
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-            value = null;
+			value = null;
 
-            if (index + 4 >= source.Length)
-                return UnexpectedEndOfInput;
+			if (index + 4 >= source.Length)
+				return UnexpectedEndOfInput;
 
-            if (source.IndexOf("null", index, 4, System.StringComparison.OrdinalIgnoreCase) != index)
-                return $"Value not recognized: {source.Substring(index, 4)}";
-            
+			if (source.IndexOf("null", index, 4, System.StringComparison.OrdinalIgnoreCase) != index)
+				return $"Value not recognized: {source.Substring(index, 4)}";
+
 			index += 4;
 			value = JsonValue.Null;
 			return null;
@@ -31,55 +31,55 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
-            value = null;
+			value = null;
 
-            var buffer = SmallBufferCache.Acquire(4);
-            var charsRead = stream.ReadBlock(buffer, 0, 4);
-            if (charsRead != 4)
-            {
-                SmallBufferCache.Release(buffer);
-                return UnexpectedEndOfInput;
-            }
+			var buffer = SmallBufferCache.Acquire(4);
+			var charsRead = stream.ReadBlock(buffer, 0, 4);
+			if (charsRead != 4)
+			{
+				SmallBufferCache.Release(buffer);
+				return UnexpectedEndOfInput;
+			}
 
-            string errorMessage = null;
-            if ((buffer[0] == 'n' || buffer[0] == 'N')
-             && (buffer[1] == 'u' || buffer[1] == 'U')
-             && (buffer[2] == 'l' || buffer[2] == 'L')
-             && (buffer[3] == 'l' || buffer[3] == 'L'))
-            {
-                value = JsonValue.Null;
-            }
-            else
-            {
-                errorMessage = $"Value not recognized: '{new string(buffer)}'.";
-            }
+			string errorMessage = null;
+			if ((buffer[0] == 'n' || buffer[0] == 'N')
+			 && (buffer[1] == 'u' || buffer[1] == 'U')
+			 && (buffer[2] == 'l' || buffer[2] == 'L')
+			 && (buffer[3] == 'l' || buffer[3] == 'L'))
+			{
+				value = JsonValue.Null;
+			}
+			else
+			{
+				errorMessage = $"Value not recognized: '{new string(buffer)}'.";
+			}
 
-            SmallBufferCache.Release(buffer);
-            return errorMessage;
+			SmallBufferCache.Release(buffer);
+			return errorMessage;
 		}
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
 			var buffer = SmallBufferCache.Acquire(4);
 			var count = await stream.ReadBlockAsync(buffer, 0, 4);
-            if (count < 4)
-            {
-                SmallBufferCache.Release(buffer);
-                return ("Unexpected end of input.", null);
-            }
+			if (count < 4)
+			{
+				SmallBufferCache.Release(buffer);
+				return ("Unexpected end of input.", null);
+			}
 
-            var value = JsonValue.Null;
-            string errorMessage = null;
-            if ((buffer[0] != 'n' && buffer[0] != 'N')
-             && (buffer[1] != 'u' && buffer[1] != 'U')
-             && (buffer[2] != 'l' && buffer[2] != 'L')
-             && (buffer[3] != 'l' && buffer[3] != 'L'))
-            {
-                value = null;
-                errorMessage = $"Value not recognized: '{value}'.";
-            }
+			var value = JsonValue.Null;
+			string errorMessage = null;
+			if ((buffer[0] != 'n' && buffer[0] != 'N')
+			 && (buffer[1] != 'u' && buffer[1] != 'U')
+			 && (buffer[2] != 'l' && buffer[2] != 'L')
+			 && (buffer[3] != 'l' && buffer[3] != 'L'))
+			{
+				value = null;
+				errorMessage = $"Value not recognized: '{value}'.";
+			}
 
-            SmallBufferCache.Release(buffer);
-            return (errorMessage, value);
+			SmallBufferCache.Release(buffer);
+			return (errorMessage, value);
 		}
 	}
 }

--- a/Manatee.Json/Parsing/NumberParser.cs
+++ b/Manatee.Json/Parsing/NumberParser.cs
@@ -10,120 +10,156 @@ namespace Manatee.Json.Parsing
 {
 	internal class NumberParser : IJsonParser
 	{
-		private static readonly int[] FibSequence = {8, 13, 21, 34, 55, 89, 144};
-		private static readonly char[] NumberChars = "0123456798-+.eE".ToCharArray();
-
 		public bool Handles(char c)
 		{
-			return c.In('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '-');
+            switch (c)
+            {
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                case '-':
+                    return true;
+            }
+            return false;
 		}
+
+        private static bool IsNumberChar(char c)
+        {
+            switch (c)
+            {
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                case '-':
+                case '+':
+                case '.':
+                case 'e':
+                case 'E':
+                    return true;
+            }
+            return false;
+        }
+
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			var bufferSize = 0;
-			var bufferLength = FibSequence[bufferSize];
-			var buffer = new char[bufferLength];
-			var bufferIndex = 0;
 			var sourceLength = source.Length;
-			while (index < sourceLength)
+            var originalIndex = index;
+            while (index < source.Length)
 			{
-				if (bufferIndex == bufferLength)
-				{
-					var currentLength = bufferLength;
-					bufferSize++;
-					bufferLength = FibSequence[bufferSize];
-					var newBuffer = new char[bufferLength];
-					Buffer.BlockCopy(buffer, 0, newBuffer, 0, currentLength*2);
-					buffer = newBuffer;
-				}
 				var c = source[index];
-				if (char.IsWhiteSpace(c) || c.In(',', ']', '}')) break;
-				var isNumber = NumberChars.Contains(c);
+				if (char.IsWhiteSpace(c) || (c == ',' || c == ']' || c == '}')) break;
+
+				var isNumber = IsNumberChar(c);
 				if (!isNumber && allowExtraChars) break;
 				if (!isNumber)
 				{
 					value = null;
-					return "Expected \',\', \']\', or \'}\'.";
+					return "Expected ',', ']', or '}'.";
 				}
-				buffer[bufferIndex] = c;
+
 				index++;
-				bufferIndex++;
 			}
-			var result = new string(buffer, 0, bufferIndex);
+
+			var result = source.Substring(originalIndex, index - originalIndex);
 			if (!double.TryParse(result, NumberStyles.Any, CultureInfo.InvariantCulture, out double dbl))
 			{
 				value = null;
 				return $"Value not recognized: '{result}'";
 			}
+
 			value = dbl;
 			return null;
 		}
-		public string TryParse(StreamReader stream, out JsonValue value)
+
+		public string TryParse(TextReader stream, out JsonValue value)
 		{
-			var bufferSize = 0;
-			var bufferLength = FibSequence[bufferSize];
-			var buffer = new char[bufferLength];
+			var buffer = StringBuilderCache.Acquire();
 			var bufferIndex = 0;
-			while (!stream.EndOfStream)
+			while (stream.Peek() != -1)
 			{
-				if (bufferIndex == bufferLength)
-				{
-					var currentLength = bufferLength;
-					bufferSize++;
-					bufferLength = FibSequence[bufferSize];
-					var newBuffer = new char[bufferLength];
-					Buffer.BlockCopy(buffer, 0, newBuffer, 0, currentLength * 2);
-					buffer = newBuffer;
-				}
 				var c = (char) stream.Peek();
-				if (char.IsWhiteSpace(c) || c.In(',', ']', '}')) break;
-				stream.Read();
-				if (!NumberChars.Contains(c))
-				{
-					value = null;
-					return "Expected \',\', \']\', or \'}\'.";
-				}
-				buffer[bufferIndex] = c;
+                if (char.IsWhiteSpace(c) || (c == ',' || c == ']' || c == '}')) break;
+
+                stream.Read(); // eat the character
+
+                if (!IsNumberChar(c))
+                {
+                    value = null;
+                    StringBuilderCache.Release(buffer);
+                    return "Expected ',', ']', or '}'.";
+                }
+
+                buffer.Append(c);
 				bufferIndex++;
 			}
-			var result = new string(buffer, 0, bufferIndex);
+
+			var result = StringBuilderCache.GetStringAndRelease(buffer);
 			if (!double.TryParse(result, NumberStyles.Any, CultureInfo.InvariantCulture, out double dbl))
 			{
 				value = null;
 				return $"Value not recognized: '{result}'";
 			}
+
 			value = dbl;
 			return null;
 		}
-		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(StreamReader stream, CancellationToken token)
+
+		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			var bufferSize = 0;
-			var bufferLength = FibSequence[bufferSize];
-			var buffer = new char[bufferLength];
-			var bufferIndex = 0;
-			while (!stream.EndOfStream)
+            var buffer = StringBuilderCache.Acquire();
+            var scratch = SmallBufferCache.Acquire(1);
+
+            string errorMessage = null;
+            while (stream.Peek() != -1)
 			{
-				if (token.IsCancellationRequested)
-					return ("Parsing incomplete. The task was cancelled.", null);
-				if (bufferIndex == bufferLength)
-				{
-					var currentLength = bufferLength;
-					bufferSize++;
-					bufferLength = FibSequence[bufferSize];
-					var newBuffer = new char[bufferLength];
-					Buffer.BlockCopy(buffer, 0, newBuffer, 0, currentLength * 2);
-					buffer = newBuffer;
-				}
+                if (token.IsCancellationRequested)
+                {
+                    errorMessage = "Parsing incomplete. The task was cancelled.";
+                    break;
+                }
+
 				var c = (char)stream.Peek();
-				if (char.IsWhiteSpace(c) || c.In(',', ']', '}')) break;
-				await stream.TryRead();
-				if (!NumberChars.Contains(c))
-					return ("Expected \',\', \']\', or \'}\'.", null);
-				buffer[bufferIndex] = c;
-				bufferIndex++;
+                if (char.IsWhiteSpace(c) || (c == ',' || c == ']' || c == '}')) break;
+
+                await stream.TryRead(scratch, 0, 1); // eat the character
+
+                if (!IsNumberChar(c))
+                {
+                    errorMessage = "Expected ',', ']', or '}'.";
+                    break;
+                }
+
+                buffer.Append(c);
 			}
-			var result = new string(buffer, 0, bufferIndex);
-			if (!double.TryParse(result, NumberStyles.Any, CultureInfo.InvariantCulture, out double dbl))
-				return ($"Value not recognized: '{result}'", null);
+
+            SmallBufferCache.Release(scratch);
+
+            if (errorMessage != null)
+            {
+                StringBuilderCache.Release(buffer);
+                return (errorMessage, null);
+            }
+
+            var result = StringBuilderCache.GetStringAndRelease(buffer);
+            if (!double.TryParse(result, NumberStyles.Any, CultureInfo.InvariantCulture, out double dbl))
+            {
+                return ($"Value not recognized: '{result}'", null);
+            }
+
 			return (null, dbl);
 		}
 	}

--- a/Manatee.Json/Parsing/NumberParser.cs
+++ b/Manatee.Json/Parsing/NumberParser.cs
@@ -12,53 +12,53 @@ namespace Manatee.Json.Parsing
 	{
 		public bool Handles(char c)
 		{
-            switch (c)
-            {
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                case '-':
-                    return true;
-            }
-            return false;
+			switch (c)
+			{
+				case '0':
+				case '1':
+				case '2':
+				case '3':
+				case '4':
+				case '5':
+				case '6':
+				case '7':
+				case '8':
+				case '9':
+				case '-':
+					return true;
+			}
+			return false;
 		}
 
-        private static bool IsNumberChar(char c)
-        {
-            switch (c)
-            {
-                case '0':
-                case '1':
-                case '2':
-                case '3':
-                case '4':
-                case '5':
-                case '6':
-                case '7':
-                case '8':
-                case '9':
-                case '-':
-                case '+':
-                case '.':
-                case 'e':
-                case 'E':
-                    return true;
-            }
-            return false;
-        }
+		private static bool IsNumberChar(char c)
+		{
+			switch (c)
+			{
+				case '0':
+				case '1':
+				case '2':
+				case '3':
+				case '4':
+				case '5':
+				case '6':
+				case '7':
+				case '8':
+				case '9':
+				case '-':
+				case '+':
+				case '.':
+				case 'e':
+				case 'E':
+					return true;
+			}
+			return false;
+		}
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
 			var sourceLength = source.Length;
-            var originalIndex = index;
-            while (index < source.Length)
+			var originalIndex = index;
+			while (index < source.Length)
 			{
 				var c = source[index];
 				if (char.IsWhiteSpace(c) || (c == ',' || c == ']' || c == '}')) break;
@@ -91,19 +91,19 @@ namespace Manatee.Json.Parsing
 			var bufferIndex = 0;
 			while (stream.Peek() != -1)
 			{
-				var c = (char) stream.Peek();
-                if (char.IsWhiteSpace(c) || (c == ',' || c == ']' || c == '}')) break;
+				var c = (char)stream.Peek();
+				if (char.IsWhiteSpace(c) || (c == ',' || c == ']' || c == '}')) break;
 
-                stream.Read(); // eat the character
+				stream.Read(); // eat the character
 
-                if (!IsNumberChar(c))
-                {
-                    value = null;
-                    StringBuilderCache.Release(buffer);
-                    return "Expected ',', ']', or '}'.";
-                }
+				if (!IsNumberChar(c))
+				{
+					value = null;
+					StringBuilderCache.Release(buffer);
+					return "Expected ',', ']', or '}'.";
+				}
 
-                buffer.Append(c);
+				buffer.Append(c);
 				bufferIndex++;
 			}
 
@@ -120,45 +120,45 @@ namespace Manatee.Json.Parsing
 
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-            var buffer = StringBuilderCache.Acquire();
-            var scratch = SmallBufferCache.Acquire(1);
+			var buffer = StringBuilderCache.Acquire();
+			var scratch = SmallBufferCache.Acquire(1);
 
-            string errorMessage = null;
-            while (stream.Peek() != -1)
+			string errorMessage = null;
+			while (stream.Peek() != -1)
 			{
-                if (token.IsCancellationRequested)
-                {
-                    errorMessage = "Parsing incomplete. The task was cancelled.";
-                    break;
-                }
+				if (token.IsCancellationRequested)
+				{
+					errorMessage = "Parsing incomplete. The task was cancelled.";
+					break;
+				}
 
 				var c = (char)stream.Peek();
-                if (char.IsWhiteSpace(c) || (c == ',' || c == ']' || c == '}')) break;
+				if (char.IsWhiteSpace(c) || (c == ',' || c == ']' || c == '}')) break;
 
-                await stream.TryRead(scratch, 0, 1); // eat the character
+				await stream.TryRead(scratch, 0, 1); // eat the character
 
-                if (!IsNumberChar(c))
-                {
-                    errorMessage = "Expected ',', ']', or '}'.";
-                    break;
-                }
+				if (!IsNumberChar(c))
+				{
+					errorMessage = "Expected ',', ']', or '}'.";
+					break;
+				}
 
-                buffer.Append(c);
+				buffer.Append(c);
 			}
 
-            SmallBufferCache.Release(scratch);
+			SmallBufferCache.Release(scratch);
 
-            if (errorMessage != null)
-            {
-                StringBuilderCache.Release(buffer);
-                return (errorMessage, null);
-            }
+			if (errorMessage != null)
+			{
+				StringBuilderCache.Release(buffer);
+				return (errorMessage, null);
+			}
 
-            var result = StringBuilderCache.GetStringAndRelease(buffer);
-            if (!double.TryParse(result, NumberStyles.Any, CultureInfo.InvariantCulture, out double dbl))
-            {
-                return ($"Value not recognized: '{result}'", null);
-            }
+			var result = StringBuilderCache.GetStringAndRelease(buffer);
+			if (!double.TryParse(result, NumberStyles.Any, CultureInfo.InvariantCulture, out double dbl))
+			{
+				return ($"Value not recognized: '{result}'", null);
+			}
 
 			return (null, dbl);
 		}

--- a/Manatee.Json/Parsing/ObjectParser.cs
+++ b/Manatee.Json/Parsing/ObjectParser.cs
@@ -61,11 +61,11 @@ namespace Manatee.Json.Parsing
 			}
 			return null;
 		}
-		public string TryParse(StreamReader stream, out JsonValue value)
+		public string TryParse(TextReader stream, out JsonValue value)
 		{
 			var obj = new JsonObject();
 			value = obj;
-			while (!stream.EndOfStream)
+			while (stream.Peek() != -1)
 			{
 				stream.Read(); // waste the '{' or ','
 				var message = stream.SkipWhiteSpace(out char c);
@@ -110,57 +110,86 @@ namespace Manatee.Json.Parsing
 			}
 			return null;
 		}
-		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(StreamReader stream, CancellationToken token)
+		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
 			var obj = new JsonObject();
-			var value = obj;
-			while (!stream.EndOfStream)
-			{
-				if (token.IsCancellationRequested)
-					return ("Parsing incomplete. The task was cancelled.", null);
-				await stream.TryRead(); // waste the '{' or ','
-				var (message, c) = await stream.SkipWhiteSpaceAsync();
-				if (message != null) return (message, value);
-				// check for empty object
-				if (c == '}')
-					if (obj.Count == 0)
-					{
-						await stream.TryRead(); // waste the '}'
-						break;
-					}
-					else return ("Expected key.", value);
+			JsonValue value = null;
+
+            var scratch = SmallBufferCache.Acquire(1);
+
+            char c;
+            string errorMessage = null;
+            while (stream.Peek() != -1)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    errorMessage = "Parsing incomplete. The task was cancelled.";
+                    break;
+                }
+                await stream.TryRead(scratch, 0, 1); // waste the '{' or ','
+                (errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
+                if (errorMessage != null) break;
+                // check for empty object
+                if (c == '}')
+                    if (obj.Count == 0)
+                    {
+                        await stream.TryRead(scratch, 0, 1); // waste the '}'
+                        break;
+                    }
+                    else
+                    {
+                        errorMessage = "Expected key.";
+                        break;
+                    }
 				// get key
-				(message, c) = await stream.SkipWhiteSpaceAsync();
-				if (message != null) return (message, value);
-				if (c != '\"') return ("Expected key.", value);
+				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
+                if (errorMessage != null) break; ;
+                if (c != '\"')
+                {
+                    errorMessage = "Expected key.";
+                    break;
+                }
+
 				JsonValue item;
-				(message, item) = await JsonParser.TryParseAsync(stream, token);
-				if (message != null) return (message, value);
+				(errorMessage, item) = await JsonParser.TryParseAsync(stream, token);
+                if (errorMessage != null) break;
 				var key = item.String;
 				// check for colon
-				(message, c) = await stream.SkipWhiteSpaceAsync();
-				if (message != null) return (message, value);
+				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
+                if (errorMessage != null) break;
 				if (c != ':')
 				{
 					obj.Add(key, null);
-					return ("Expected ':'.", value);
+					errorMessage ="Expected ':'.";
+                    break;
 				}
-				await stream.TryRead(); // waste the ':'
-				// get value (whitespace is removed in Parse)
-				message = JsonParser.Parse(stream, out item);
+				await stream.TryRead(scratch, 0, 1); // waste the ':'
+                                                     // get value (whitespace is removed in Parse)
+                errorMessage = JsonParser.Parse(stream, out item);
 				obj.Add(key, item);
-				if (message != null) return (message, value);
-				(message, c) = await stream.SkipWhiteSpaceAsync();
-				if (message != null) return (message, value);
+				if (errorMessage != null) break;
+				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
+                if (errorMessage != null) break;
 				// check for end or separator
 				if (c == '}')
 				{
-					await stream.TryRead(); // waste the '}'
+					await stream.TryRead(scratch, 0, 1); // waste the '}'
 					break;
 				}
-				if (c != ',') return ("Expected ','.", value);
+                if (c != ',')
+                {
+                    errorMessage = "Expected ','.";
+                    break;
+                }
 			}
-			return (null, value);
+
+            if (errorMessage == null)
+            {
+                value = obj;
+            }
+
+            SmallBufferCache.Release(scratch);
+			return (errorMessage, value);
 		}
 	}
 }

--- a/Manatee.Json/Parsing/ObjectParser.cs
+++ b/Manatee.Json/Parsing/ObjectParser.cs
@@ -94,7 +94,7 @@ namespace Manatee.Json.Parsing
 					return "Expected ':'.";
 				}
 				stream.Read(); // waste the ':'
-				// get value (whitespace is removed in Parse)
+							   // get value (whitespace is removed in Parse)
 				message = JsonParser.Parse(stream, out item);
 				obj.Add(key, item);
 				if (message != null) return message;
@@ -115,80 +115,80 @@ namespace Manatee.Json.Parsing
 			var obj = new JsonObject();
 			JsonValue value = null;
 
-            var scratch = SmallBufferCache.Acquire(1);
+			var scratch = SmallBufferCache.Acquire(1);
 
-            char c;
-            string errorMessage = null;
-            while (stream.Peek() != -1)
-            {
-                if (token.IsCancellationRequested)
-                {
-                    errorMessage = "Parsing incomplete. The task was cancelled.";
-                    break;
-                }
-                await stream.TryRead(scratch, 0, 1); // waste the '{' or ','
-                (errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
-                if (errorMessage != null) break;
-                // check for empty object
-                if (c == '}')
-                    if (obj.Count == 0)
-                    {
-                        await stream.TryRead(scratch, 0, 1); // waste the '}'
-                        break;
-                    }
-                    else
-                    {
-                        errorMessage = "Expected key.";
-                        break;
-                    }
+			char c;
+			string errorMessage = null;
+			while (stream.Peek() != -1)
+			{
+				if (token.IsCancellationRequested)
+				{
+					errorMessage = "Parsing incomplete. The task was cancelled.";
+					break;
+				}
+				await stream.TryRead(scratch, 0, 1); // waste the '{' or ','
+				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
+				if (errorMessage != null) break;
+				// check for empty object
+				if (c == '}')
+					if (obj.Count == 0)
+					{
+						await stream.TryRead(scratch, 0, 1); // waste the '}'
+						break;
+					}
+					else
+					{
+						errorMessage = "Expected key.";
+						break;
+					}
 				// get key
 				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
-                if (errorMessage != null) break; ;
-                if (c != '\"')
-                {
-                    errorMessage = "Expected key.";
-                    break;
-                }
+				if (errorMessage != null) break; ;
+				if (c != '\"')
+				{
+					errorMessage = "Expected key.";
+					break;
+				}
 
 				JsonValue item;
 				(errorMessage, item) = await JsonParser.TryParseAsync(stream, token);
-                if (errorMessage != null) break;
+				if (errorMessage != null) break;
 				var key = item.String;
 				// check for colon
 				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
-                if (errorMessage != null) break;
+				if (errorMessage != null) break;
 				if (c != ':')
 				{
 					obj.Add(key, null);
-					errorMessage ="Expected ':'.";
-                    break;
+					errorMessage = "Expected ':'.";
+					break;
 				}
 				await stream.TryRead(scratch, 0, 1); // waste the ':'
-                                                     // get value (whitespace is removed in Parse)
-                errorMessage = JsonParser.Parse(stream, out item);
+													 // get value (whitespace is removed in Parse)
+				errorMessage = JsonParser.Parse(stream, out item);
 				obj.Add(key, item);
 				if (errorMessage != null) break;
 				(errorMessage, c) = await stream.SkipWhiteSpaceAsync(scratch);
-                if (errorMessage != null) break;
+				if (errorMessage != null) break;
 				// check for end or separator
 				if (c == '}')
 				{
 					await stream.TryRead(scratch, 0, 1); // waste the '}'
 					break;
 				}
-                if (c != ',')
-                {
-                    errorMessage = "Expected ','.";
-                    break;
-                }
+				if (c != ',')
+				{
+					errorMessage = "Expected ','.";
+					break;
+				}
 			}
 
-            if (errorMessage == null)
-            {
-                value = obj;
-            }
+			if (errorMessage == null)
+			{
+				value = obj;
+			}
 
-            SmallBufferCache.Release(scratch);
+			SmallBufferCache.Release(scratch);
 			return (errorMessage, value);
 		}
 	}

--- a/Manatee.Json/Parsing/StringParser.cs
+++ b/Manatee.Json/Parsing/StringParser.cs
@@ -17,483 +17,483 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-            value = null;
+			value = null;
 
-            bool complete = false;
-            bool mustInterpret = false;
-            int originalIndex = ++index; // eat initial '"'
-            while (index < source.Length)
-            {
-                if (source[index] == '\\')
-                {
-                    mustInterpret = true;
-                    break;
-                }
-                else if (source[index] == '"')
-                {
-                    complete = true;
-                    break;
-                }
+			bool complete = false;
+			bool mustInterpret = false;
+			int originalIndex = ++index; // eat initial '"'
+			while (index < source.Length)
+			{
+				if (source[index] == '\\')
+				{
+					mustInterpret = true;
+					break;
+				}
+				else if (source[index] == '"')
+				{
+					complete = true;
+					break;
+				}
 
-                index++;
-            }
+				index++;
+			}
 
-            if (!mustInterpret)
-            {
-                if (!complete)
-                    return "Could not find end of string value.";
+			if (!mustInterpret)
+			{
+				if (!complete)
+					return "Could not find end of string value.";
 
-                value = source.Substring(originalIndex, (index - originalIndex));
+				value = source.Substring(originalIndex, (index - originalIndex));
 
-                index += 1; // eat the trailing '"'
-                return null;
-            }
-            else
-            {
-                index = originalIndex;
-                return TryParseInterpretedString(source, ref index, out value, allowExtraChars);
-            }
+				index += 1; // eat the trailing '"'
+				return null;
+			}
+			else
+			{
+				index = originalIndex;
+				return TryParseInterpretedString(source, ref index, out value, allowExtraChars);
+			}
 		}
 
-        private string TryParseInterpretedString(string source, ref int index, out JsonValue value, bool allowExtraChars)
-        {
-            value = null;
-
-            string errorMessage = null;
-            var builder = StringBuilderCache.Acquire();
-            var complete = false;
-            while (index < source.Length)
-            {
-                var c = source[index++];
-                if (c != '\\')
-                {
-                    if (c == '"')
-                    {
-                        complete = true;
-                        break;
-                    }
-
-                    builder.Append(c);
-                }
-                else
-                {
-                    if (index >= source.Length)
-                        return "Could not find end of string value.";
-
-                    string append = null;
-                    switch (source[index++])
-                    {
-                        case 'b':
-                            append = "\b";
-                            break;
-                        case 'f':
-                            append = "\f";
-                            break;
-                        case 'n':
-                            append = "\n";
-                            break;
-                        case 'r':
-                            append = "\r";
-                            break;
-                        case 't':
-                            append = "\t";
-                            break;
-
-                        case 'u':
-                            var length = 4;
-                            var hex = int.Parse(source.Substring(index, 4), NumberStyles.HexNumber);
-                            if (source.IndexOf("\\u", index + 4, 2) == index + 4)
-                            {
-                                var hex2 = int.Parse(source.Substring(index + 6, 4), NumberStyles.HexNumber);
-                                hex = (hex - 0xD800) * 0x400 + (hex2 - 0xDC00) % 0x400 + 0x10000;
-                                length += 6;
-                            }
-                            append = char.ConvertFromUtf32(hex);
-                            index += length;
-                            break;
-
-                        case '"':
-                            append = "\"";
-                            break;
-                        case '\\':
-                            append = "\\";
-                            break;
-
-                            // Is this correct?
-                        case '/':
-                            append = "/";
-                            break;
-
-                        default:
-                            errorMessage = $"Invalid escape sequence: '\\{c}'.";
-                            break;
-                    }
-
-                    if (append != null)
-                    {
-                        builder.Append(append);
-                    }
-                    else
-                    {
-                        break;
-                    }
-                }
-            }
-
-            if (!complete)
-            {
-                value = null;
-                StringBuilderCache.Release(builder);
-                return "Could not find end of string value.";
-            }
-            value = StringBuilderCache.GetStringAndRelease(builder);
-            return errorMessage;
-        }
-
-        public string TryParse(TextReader stream, out JsonValue value)
+		private string TryParseInterpretedString(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-            value = null;
+			value = null;
 
-            stream.Read(); // waste the '"'
+			string errorMessage = null;
+			var builder = StringBuilderCache.Acquire();
+			var complete = false;
+			while (index < source.Length)
+			{
+				var c = source[index++];
+				if (c != '\\')
+				{
+					if (c == '"')
+					{
+						complete = true;
+						break;
+					}
 
-            var builder = StringBuilderCache.Acquire();
+					builder.Append(c);
+				}
+				else
+				{
+					if (index >= source.Length)
+						return "Could not find end of string value.";
 
-            var complete = false;
-            bool mustInterpret = false;
-            char c;
-            while ((c = (char)stream.Peek()) != -1)
-            {
-                if (c == '\\')
-                {
-                    mustInterpret = true;
-                    break;
-                }
+					string append = null;
+					switch (source[index++])
+					{
+						case 'b':
+							append = "\b";
+							break;
+						case 'f':
+							append = "\f";
+							break;
+						case 'n':
+							append = "\n";
+							break;
+						case 'r':
+							append = "\r";
+							break;
+						case 't':
+							append = "\t";
+							break;
 
-                stream.Read(); // eat the character
-                if (c == '"')
-                {
-                    complete = true;
-                    break;
-                }
+						case 'u':
+							var length = 4;
+							var hex = int.Parse(source.Substring(index, 4), NumberStyles.HexNumber);
+							if (source.IndexOf("\\u", index + 4, 2) == index + 4)
+							{
+								var hex2 = int.Parse(source.Substring(index + 6, 4), NumberStyles.HexNumber);
+								hex = (hex - 0xD800) * 0x400 + (hex2 - 0xDC00) % 0x400 + 0x10000;
+								length += 6;
+							}
+							append = char.ConvertFromUtf32(hex);
+							index += length;
+							break;
 
-                builder.Append(c);
-            }
+						case '"':
+							append = "\"";
+							break;
+						case '\\':
+							append = "\\";
+							break;
 
-            // if there are not any escape sequences--most of a JSON's strings--just
-            // return the string as-is.
-            if (!mustInterpret)
-            {
-                if (!complete)
-                    return "Could not find end of string value.";
+						// Is this correct?
+						case '/':
+							append = "/";
+							break;
 
-                value = StringBuilderCache.GetStringAndRelease(builder);
-                return null;
-            }
-            else
-            {
-                // NOTE: TryParseInterpretedString is responsible for releasing builder
-                // NOTE: TryParseInterpretedString assumes stream is sitting at the '\\'
-                return TryParseInterpretedString(builder, stream, out value);
-            }
-        }
+						default:
+							errorMessage = $"Invalid escape sequence: '\\{c}'.";
+							break;
+					}
 
-        private string TryParseInterpretedString(StringBuilder builder, TextReader stream, out JsonValue value)
-        {
-            // NOTE: `builder` contains the portion of the string found in `stream`, up to the first
-            //       (possible) escape sequence.
-            System.Diagnostics.Debug.Assert('\\' == (char)stream.Peek());
+					if (append != null)
+					{
+						builder.Append(append);
+					}
+					else
+					{
+						break;
+					}
+				}
+			}
 
-            value = null;
-
-            string errorMessage = null;
-            bool complete = false;
-
-            int? previousHex = null;
-
-            char c;
-            while ((c = (char)stream.Peek()) != -1)
-            {
-                stream.Read(); // eat this character
-
-                if (c == '\\')
-                {
-                    // escape sequence
-                    var lookAhead = (char)stream.Peek();
-                    if (!MustInterpretComplex(lookAhead))
-                    {
-                        stream.Read(); // eat the simple escape
-                        c = InterpretSimpleEscapeSequence(lookAhead);
-                    }
-                    else
-                    {
-                        // NOTE: Currently we only handle 'u' here
-                        if (lookAhead != 'u')
-                        {
-                            StringBuilderCache.Release(builder);
-                            return $"Invalid escape sequence: '\\{lookAhead}'.";
-                        }
-
-                        var buffer = SmallBufferCache.Acquire(4);
-                        stream.Read(buffer, 0, 4);
-                        var hexString = new string(buffer);
-                        var currentHex = int.Parse(hexString, NumberStyles.HexNumber);
-
-                        if (previousHex != null)
-                        {
-                            // Our last character was \u, so combine and emit the UTF32 codepoint
-                            currentHex = ((previousHex - 0xD800) * 0x400 + (currentHex - 0xDC00) % 0x400 + 0x10000).Value;
-                            builder.Append(char.ConvertFromUtf32(currentHex));
-                            previousHex = null;
-                        }
-                        else
-                        {
-                            previousHex = currentHex;
-                        }
-
-                        SmallBufferCache.Release(buffer);
-                        continue;
-                    }
-                }
-                else if (c == '"')
-                {
-                    complete = true;
-                    break;
-                }
-
-                // Check if last character was \u, and if so emit it as-is, because
-                // this character is not a continuation of a UTF-32 escape sequence
-                if (previousHex != null)
-                {
-                    builder.Append(char.ConvertFromUtf32(previousHex.Value));
-                    previousHex = null;
-                }
-
-                // non-escape sequence
-                builder.Append(c);
-            }
-
-            // if we had a hanging UTF32 escape sequence, apply it now
-            if (previousHex != null)
-            {
-                builder.Append(char.ConvertFromUtf32(previousHex.Value));
-            }
-
-            if (!complete)
-            {
-                value = null;
-                StringBuilderCache.Release(builder);
-                return "Could not find end of string value.";
-            }
-
-            value = StringBuilderCache.GetStringAndRelease(builder);
-            return errorMessage;
-        }
-
-        /// <summary>
-        /// Indicates whether or not the lookahead character is a 
-        /// complex escape code.
-        /// </summary>
-        /// <param name="lookAhead">Lookahead character.</param>
-        /// <returns><c>true</c> if and only if <paramref name="lookAhead"/>
-        /// would require complex interpretation.</returns>
-        private static bool MustInterpretComplex(char lookAhead)
-        {
-            switch (lookAhead)
-            {
-                case '"':
-                case '/':
-                case '\\':
-                    // These escape 'as-is'
-                    return false;
-                case 'b':
-                case 'f':
-                case 'n':
-                case 'r':
-                case 't':
-                    // These escape as an escape char
-                    return false;
-
-                case 'u':
-                    // this requires more work...
-                    return true;
-
-                default:
-                    // this is an error, which our complex handler will report
-                    return true;
-            }
-        }
-
-        private static char InterpretSimpleEscapeSequence(char lookAhead)
-        {
-            switch (lookAhead)
-            {
-                case 'b':
-                    return '\b';
-                case 'f':
-                    return '\f';
-                case 'n':
-                    return '\n';
-                case 'r':
-                    return '\r';
-                case 't':
-                    return '\t';
-                default:
-                    return lookAhead;
-            }
-        }
-
-        public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
-		{
-            var scratch = SmallBufferCache.Acquire(4);
-
-            await stream.TryRead(scratch, 0, 1); // waste the '"'
-
-            var builder = StringBuilderCache.Acquire();
-
-            var complete = false;
-            bool mustInterpret = false;
-            char c;
-            while ((c = (char)stream.Peek()) != -1)
-            {
-                if (c == '\\')
-                {
-                    mustInterpret = true;
-                    break;
-                }
-
-                await stream.TryRead(scratch, 0, 1); // eat the character
-                if (c == '"')
-                {
-                    complete = true;
-                    break;
-                }
-
-                builder.Append(c);
-            }
-
-            // if there are not any escape sequences--most of a JSON's strings--just
-            // return the string as-is.
-            if (!mustInterpret)
-            {
-                SmallBufferCache.Release(scratch);
-
-                string errorMessage = null;
-                JsonValue value = null;
-                if (!complete)
-                {
-                    errorMessage = "Could not find end of string value.";
-                }
-                else
-                { 
-                    value = StringBuilderCache.GetStringAndRelease(builder);
-                }
-
-                return (errorMessage, value);
-            }
-            else
-            {
-                // NOTE: TryParseInterpretedString is responsible for releasing builder
-                // NOTE: TryParseInterpretedString assumes stream is sitting at the '\\'
-                // NOTE: TryParseInterpretedString assumes scratch can hold at least 4 chars
-                return await TryParseInterpretedStringAsync(builder, stream, scratch);
-            }
+			if (!complete)
+			{
+				value = null;
+				StringBuilderCache.Release(builder);
+				return "Could not find end of string value.";
+			}
+			value = StringBuilderCache.GetStringAndRelease(builder);
+			return errorMessage;
 		}
 
-        private async Task<(string errorMessage, JsonValue value)> TryParseInterpretedStringAsync(StringBuilder builder, TextReader stream, char[] scratch)
-        {
-            // NOTE: `builder` contains the portion of the string found in `stream`, up to the first
-            //       (possible) escape sequence.
-            System.Diagnostics.Debug.Assert('\\' == (char)stream.Peek());
-            System.Diagnostics.Debug.Assert(scratch.Length >= 4);
+		public string TryParse(TextReader stream, out JsonValue value)
+		{
+			value = null;
 
-            bool complete = false;
+			stream.Read(); // waste the '"'
 
-            int? previousHex = null;
+			var builder = StringBuilderCache.Acquire();
 
-            char c;
-            while ((c = (char)stream.Peek()) != -1)
-            {
-                await stream.TryRead(scratch, 0, 1); // eat this character
+			var complete = false;
+			bool mustInterpret = false;
+			char c;
+			while ((c = (char)stream.Peek()) != -1)
+			{
+				if (c == '\\')
+				{
+					mustInterpret = true;
+					break;
+				}
 
-                if (c == '\\')
-                {
-                    // escape sequence
-                    var lookAhead = (char)stream.Peek();
-                    if (!MustInterpretComplex(lookAhead))
-                    {
-                        await stream.TryRead(scratch, 0, 1); // eat the simple escape
-                        c = InterpretSimpleEscapeSequence(lookAhead);
-                    }
-                    else
-                    {
-                        // NOTE: Currently we only handle 'u' here
-                        if (lookAhead != 'u')
-                        {
-                            StringBuilderCache.Release(builder);
-                            SmallBufferCache.Release(scratch);
-                            return ($"Invalid escape sequence: '\\{lookAhead}'.", null);
-                        }
+				stream.Read(); // eat the character
+				if (c == '"')
+				{
+					complete = true;
+					break;
+				}
 
-                        var charsRead = await stream.ReadAsync(scratch, 0, 4);
-                        if (charsRead < 4)
-                        {
-                            StringBuilderCache.Release(builder);
-                            SmallBufferCache.Release(scratch);
-                            return ("Could not find end of string value.", null);
-                        }
+				builder.Append(c);
+			}
 
-                        var hexString = new string(scratch, 0, 4);
-                        var currentHex = int.Parse(hexString, NumberStyles.HexNumber);
+			// if there are not any escape sequences--most of a JSON's strings--just
+			// return the string as-is.
+			if (!mustInterpret)
+			{
+				if (!complete)
+					return "Could not find end of string value.";
 
-                        if (previousHex != null)
-                        {
-                            // Our last character was \u, so combine and emit the UTF32 codepoint
-                            currentHex = ((previousHex - 0xD800) * 0x400 + (currentHex - 0xDC00) % 0x400 + 0x10000).Value;
-                            builder.Append(char.ConvertFromUtf32(currentHex));
-                            previousHex = null;
-                        }
-                        else
-                        {
-                            previousHex = currentHex;
-                        }
+				value = StringBuilderCache.GetStringAndRelease(builder);
+				return null;
+			}
+			else
+			{
+				// NOTE: TryParseInterpretedString is responsible for releasing builder
+				// NOTE: TryParseInterpretedString assumes stream is sitting at the '\\'
+				return TryParseInterpretedString(builder, stream, out value);
+			}
+		}
 
-                        continue;
-                    }
-                }
-                else if (c == '"')
-                {
-                    complete = true;
-                    break;
-                }
+		private string TryParseInterpretedString(StringBuilder builder, TextReader stream, out JsonValue value)
+		{
+			// NOTE: `builder` contains the portion of the string found in `stream`, up to the first
+			//       (possible) escape sequence.
+			System.Diagnostics.Debug.Assert('\\' == (char)stream.Peek());
 
-                // Check if last character was \u, and if so emit it as-is, because
-                // this character is not a continuation of a UTF-32 escape sequence
-                if (previousHex != null)
-                {
-                    builder.Append(char.ConvertFromUtf32(previousHex.Value));
-                    previousHex = null;
-                }
+			value = null;
 
-                // non-escape sequence
-                builder.Append(c);
-            }
+			string errorMessage = null;
+			bool complete = false;
 
-            SmallBufferCache.Release(scratch);
+			int? previousHex = null;
 
-            // if we had a hanging UTF32 escape sequence, apply it now
-            if (previousHex != null)
-            {
-                builder.Append(char.ConvertFromUtf32(previousHex.Value));
-            }
+			char c;
+			while ((c = (char)stream.Peek()) != -1)
+			{
+				stream.Read(); // eat this character
 
-            if (!complete)
-            {
-                StringBuilderCache.Release(builder);
-                return ("Could not find end of string value.", null);
-            }
+				if (c == '\\')
+				{
+					// escape sequence
+					var lookAhead = (char)stream.Peek();
+					if (!MustInterpretComplex(lookAhead))
+					{
+						stream.Read(); // eat the simple escape
+						c = InterpretSimpleEscapeSequence(lookAhead);
+					}
+					else
+					{
+						// NOTE: Currently we only handle 'u' here
+						if (lookAhead != 'u')
+						{
+							StringBuilderCache.Release(builder);
+							return $"Invalid escape sequence: '\\{lookAhead}'.";
+						}
 
-            JsonValue value = StringBuilderCache.GetStringAndRelease(builder);
-            return (null, value);
-        }
-    }
+						var buffer = SmallBufferCache.Acquire(4);
+						stream.Read(buffer, 0, 4);
+						var hexString = new string(buffer);
+						var currentHex = int.Parse(hexString, NumberStyles.HexNumber);
+
+						if (previousHex != null)
+						{
+							// Our last character was \u, so combine and emit the UTF32 codepoint
+							currentHex = ((previousHex - 0xD800) * 0x400 + (currentHex - 0xDC00) % 0x400 + 0x10000).Value;
+							builder.Append(char.ConvertFromUtf32(currentHex));
+							previousHex = null;
+						}
+						else
+						{
+							previousHex = currentHex;
+						}
+
+						SmallBufferCache.Release(buffer);
+						continue;
+					}
+				}
+				else if (c == '"')
+				{
+					complete = true;
+					break;
+				}
+
+				// Check if last character was \u, and if so emit it as-is, because
+				// this character is not a continuation of a UTF-32 escape sequence
+				if (previousHex != null)
+				{
+					builder.Append(char.ConvertFromUtf32(previousHex.Value));
+					previousHex = null;
+				}
+
+				// non-escape sequence
+				builder.Append(c);
+			}
+
+			// if we had a hanging UTF32 escape sequence, apply it now
+			if (previousHex != null)
+			{
+				builder.Append(char.ConvertFromUtf32(previousHex.Value));
+			}
+
+			if (!complete)
+			{
+				value = null;
+				StringBuilderCache.Release(builder);
+				return "Could not find end of string value.";
+			}
+
+			value = StringBuilderCache.GetStringAndRelease(builder);
+			return errorMessage;
+		}
+
+		/// <summary>
+		/// Indicates whether or not the lookahead character is a 
+		/// complex escape code.
+		/// </summary>
+		/// <param name="lookAhead">Lookahead character.</param>
+		/// <returns><c>true</c> if and only if <paramref name="lookAhead"/>
+		/// would require complex interpretation.</returns>
+		private static bool MustInterpretComplex(char lookAhead)
+		{
+			switch (lookAhead)
+			{
+				case '"':
+				case '/':
+				case '\\':
+					// These escape 'as-is'
+					return false;
+				case 'b':
+				case 'f':
+				case 'n':
+				case 'r':
+				case 't':
+					// These escape as an escape char
+					return false;
+
+				case 'u':
+					// this requires more work...
+					return true;
+
+				default:
+					// this is an error, which our complex handler will report
+					return true;
+			}
+		}
+
+		private static char InterpretSimpleEscapeSequence(char lookAhead)
+		{
+			switch (lookAhead)
+			{
+				case 'b':
+					return '\b';
+				case 'f':
+					return '\f';
+				case 'n':
+					return '\n';
+				case 'r':
+					return '\r';
+				case 't':
+					return '\t';
+				default:
+					return lookAhead;
+			}
+		}
+
+		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
+		{
+			var scratch = SmallBufferCache.Acquire(4);
+
+			await stream.TryRead(scratch, 0, 1); // waste the '"'
+
+			var builder = StringBuilderCache.Acquire();
+
+			var complete = false;
+			bool mustInterpret = false;
+			char c;
+			while ((c = (char)stream.Peek()) != -1)
+			{
+				if (c == '\\')
+				{
+					mustInterpret = true;
+					break;
+				}
+
+				await stream.TryRead(scratch, 0, 1); // eat the character
+				if (c == '"')
+				{
+					complete = true;
+					break;
+				}
+
+				builder.Append(c);
+			}
+
+			// if there are not any escape sequences--most of a JSON's strings--just
+			// return the string as-is.
+			if (!mustInterpret)
+			{
+				SmallBufferCache.Release(scratch);
+
+				string errorMessage = null;
+				JsonValue value = null;
+				if (!complete)
+				{
+					errorMessage = "Could not find end of string value.";
+				}
+				else
+				{
+					value = StringBuilderCache.GetStringAndRelease(builder);
+				}
+
+				return (errorMessage, value);
+			}
+			else
+			{
+				// NOTE: TryParseInterpretedString is responsible for releasing builder
+				// NOTE: TryParseInterpretedString assumes stream is sitting at the '\\'
+				// NOTE: TryParseInterpretedString assumes scratch can hold at least 4 chars
+				return await TryParseInterpretedStringAsync(builder, stream, scratch);
+			}
+		}
+
+		private async Task<(string errorMessage, JsonValue value)> TryParseInterpretedStringAsync(StringBuilder builder, TextReader stream, char[] scratch)
+		{
+			// NOTE: `builder` contains the portion of the string found in `stream`, up to the first
+			//       (possible) escape sequence.
+			System.Diagnostics.Debug.Assert('\\' == (char)stream.Peek());
+			System.Diagnostics.Debug.Assert(scratch.Length >= 4);
+
+			bool complete = false;
+
+			int? previousHex = null;
+
+			char c;
+			while ((c = (char)stream.Peek()) != -1)
+			{
+				await stream.TryRead(scratch, 0, 1); // eat this character
+
+				if (c == '\\')
+				{
+					// escape sequence
+					var lookAhead = (char)stream.Peek();
+					if (!MustInterpretComplex(lookAhead))
+					{
+						await stream.TryRead(scratch, 0, 1); // eat the simple escape
+						c = InterpretSimpleEscapeSequence(lookAhead);
+					}
+					else
+					{
+						// NOTE: Currently we only handle 'u' here
+						if (lookAhead != 'u')
+						{
+							StringBuilderCache.Release(builder);
+							SmallBufferCache.Release(scratch);
+							return ($"Invalid escape sequence: '\\{lookAhead}'.", null);
+						}
+
+						var charsRead = await stream.ReadAsync(scratch, 0, 4);
+						if (charsRead < 4)
+						{
+							StringBuilderCache.Release(builder);
+							SmallBufferCache.Release(scratch);
+							return ("Could not find end of string value.", null);
+						}
+
+						var hexString = new string(scratch, 0, 4);
+						var currentHex = int.Parse(hexString, NumberStyles.HexNumber);
+
+						if (previousHex != null)
+						{
+							// Our last character was \u, so combine and emit the UTF32 codepoint
+							currentHex = ((previousHex - 0xD800) * 0x400 + (currentHex - 0xDC00) % 0x400 + 0x10000).Value;
+							builder.Append(char.ConvertFromUtf32(currentHex));
+							previousHex = null;
+						}
+						else
+						{
+							previousHex = currentHex;
+						}
+
+						continue;
+					}
+				}
+				else if (c == '"')
+				{
+					complete = true;
+					break;
+				}
+
+				// Check if last character was \u, and if so emit it as-is, because
+				// this character is not a continuation of a UTF-32 escape sequence
+				if (previousHex != null)
+				{
+					builder.Append(char.ConvertFromUtf32(previousHex.Value));
+					previousHex = null;
+				}
+
+				// non-escape sequence
+				builder.Append(c);
+			}
+
+			SmallBufferCache.Release(scratch);
+
+			// if we had a hanging UTF32 escape sequence, apply it now
+			if (previousHex != null)
+			{
+				builder.Append(char.ConvertFromUtf32(previousHex.Value));
+			}
+
+			if (!complete)
+			{
+				StringBuilderCache.Release(builder);
+				return ("Could not find end of string value.", null);
+			}
+
+			JsonValue value = StringBuilderCache.GetStringAndRelease(builder);
+			return (null, value);
+		}
+	}
 }

--- a/Manatee.Json/Parsing/StringParser.cs
+++ b/Manatee.Json/Parsing/StringParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using System.Threading;
@@ -13,239 +14,486 @@ namespace Manatee.Json.Parsing
 		{
 			return c == '\"';
 		}
+
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			string errorMessage = null;
-			var builder = new StringBuilder();
-			var sourceLength = source.Length;
-			var foundEscape = false;
-			var complete = false;
-			index++;
-			while (index < sourceLength)
-			{
-				var c = source[index];
-				var append = new string(c, 1);
-				index++;
-				if (foundEscape)
-				{
-					switch (c)
-					{
-						case '"':
-						case '/':
-						case '\\':
-							break;
-						case 'b':
-							append = "\b";
-							break;
-						case 'f':
-							append = "\f";
-							break;
-						case 'n':
-							append = "\n";
-							break;
-						case 'r':
-							append = "\r";
-							break;
-						case 't':
-							append = "\t";
-							break;
-						case 'u':
-							var length = 4;
-							var hex = int.Parse(source.Substring(index, 4), NumberStyles.HexNumber);
-							if (source.Substring(index + 4, 2) == "\\u")
-							{
-								var hex2 = int.Parse(source.Substring(index + 6, 4), NumberStyles.HexNumber);
-								hex = (hex - 0xD800) * 0x400 + (hex2 - 0xDC00) % 0x400 + 0x10000;
-								length += 6;
-							}
-							append = char.ConvertFromUtf32(hex);
-							index += length;
-							break;
-						default:
-							errorMessage = $"Invalid escape sequence: '\\{c}'.";
-							break;
-					}
-				}
-				else if (c == '"')
-				{
-					complete = true;
-					break;
-				}
-				foundEscape = !foundEscape && c == '\\';
-				if (!foundEscape)
-					builder.Append(append);
-			}
-			if (!complete)
-			{
-				value = null;
-				return "Could not find end of string value.";
-			}
-			value = builder.ToString();
-			return errorMessage;
+            value = null;
+
+            bool complete = false;
+            bool mustInterpret = false;
+            int originalIndex = ++index; // eat initial '"'
+            while (index < source.Length)
+            {
+                if (source[index] == '\\')
+                {
+                    mustInterpret = true;
+                    break;
+                }
+                else if (source[index] == '"')
+                {
+                    complete = true;
+                    break;
+                }
+
+                index++;
+            }
+
+            if (!mustInterpret)
+            {
+                if (!complete)
+                    return "Could not find end of string value.";
+
+                value = source.Substring(originalIndex, (index - originalIndex));
+
+                index += 1; // eat the trailing '"'
+                return null;
+            }
+            else
+            {
+                index = originalIndex;
+                return TryParseInterpretedString(source, ref index, out value, allowExtraChars);
+            }
 		}
-		public string TryParse(StreamReader stream, out JsonValue value)
+
+        private string TryParseInterpretedString(string source, ref int index, out JsonValue value, bool allowExtraChars)
+        {
+            value = null;
+
+            string errorMessage = null;
+            var builder = StringBuilderCache.Acquire();
+            var complete = false;
+            while (index < source.Length)
+            {
+                var c = source[index++];
+                if (c != '\\')
+                {
+                    if (c == '"')
+                    {
+                        complete = true;
+                        break;
+                    }
+
+                    builder.Append(c);
+                }
+                else
+                {
+                    if (index >= source.Length)
+                        return "Could not find end of string value.";
+
+                    string append = null;
+                    switch (source[index++])
+                    {
+                        case 'b':
+                            append = "\b";
+                            break;
+                        case 'f':
+                            append = "\f";
+                            break;
+                        case 'n':
+                            append = "\n";
+                            break;
+                        case 'r':
+                            append = "\r";
+                            break;
+                        case 't':
+                            append = "\t";
+                            break;
+
+                        case 'u':
+                            var length = 4;
+                            var hex = int.Parse(source.Substring(index, 4), NumberStyles.HexNumber);
+                            if (source.IndexOf("\\u", index + 4, 2) == index + 4)
+                            {
+                                var hex2 = int.Parse(source.Substring(index + 6, 4), NumberStyles.HexNumber);
+                                hex = (hex - 0xD800) * 0x400 + (hex2 - 0xDC00) % 0x400 + 0x10000;
+                                length += 6;
+                            }
+                            append = char.ConvertFromUtf32(hex);
+                            index += length;
+                            break;
+
+                        case '"':
+                            append = "\"";
+                            break;
+                        case '\\':
+                            append = "\\";
+                            break;
+
+                            // Is this correct?
+                        case '/':
+                            append = "/";
+                            break;
+
+                        default:
+                            errorMessage = $"Invalid escape sequence: '\\{c}'.";
+                            break;
+                    }
+
+                    if (append != null)
+                    {
+                        builder.Append(append);
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (!complete)
+            {
+                value = null;
+                StringBuilderCache.Release(builder);
+                return "Could not find end of string value.";
+            }
+            value = StringBuilderCache.GetStringAndRelease(builder);
+            return errorMessage;
+        }
+
+        public string TryParse(TextReader stream, out JsonValue value)
 		{
-			string errorMessage = null;
-			var builder = new StringBuilder();
-			stream.Read(); // waste the '"'
-			var foundEscape = false;
-			var complete = false;
-			string backup = null;
-			while (!stream.EndOfStream)
-			{
-				char c;
-				if (!string.IsNullOrEmpty(backup))
-				{
-					c = backup[0];
-					backup = backup.Substring(1);
-				}
-				else c = (char) stream.Read();
-				var append = new string(c, 1);
-				if (foundEscape)
-				{
-					switch (c)
-					{
-						case '"':
-						case '/':
-						case '\\':
-							break;
-						case 'b':
-							append = "\b";
-							break;
-						case 'f':
-							append = "\f";
-							break;
-						case 'n':
-							append = "\n";
-							break;
-						case 'r':
-							append = "\r";
-							break;
-						case 't':
-							append = "\t";
-							break;
-						case 'u':
-							var buffer = new char[4];
-							stream.Read(buffer, 0, 4);
-							var hexString = new string(buffer);
-							var hex = int.Parse(hexString, NumberStyles.HexNumber);
-							stream.Read(buffer, 0, 2);
-							backup = new string(buffer, 0, 2);
-							if (backup == "\\u")
-							{
-								stream.Read(buffer, 0, 4);
-								hexString = new string(buffer);
-								backup = null;
-								var hex2 = int.Parse(hexString, NumberStyles.HexNumber);
-								hex = (hex - 0xD800) * 0x400 + (hex2 - 0xDC00) % 0x400 + 0x10000;
-							}
-							append = char.ConvertFromUtf32(hex);
-							break;
-						default:
-							errorMessage = $"Invalid escape sequence: '\\{c}'.";
-							break;
-					}
-				}
-				else if (c == '"')
-				{
-					complete = true;
-					break;
-				}
-				foundEscape = !foundEscape && c == '\\';
-				if (!foundEscape)
-					builder.Append(append);
-			}
-			if (!complete)
-			{
-				value = null;
-				return "Could not find end of string value.";
-			}
-			value = builder.ToString();
-			return errorMessage;
-		}
-		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(StreamReader stream, CancellationToken token)
+            value = null;
+
+            stream.Read(); // waste the '"'
+
+            var builder = StringBuilderCache.Acquire();
+
+            var complete = false;
+            bool mustInterpret = false;
+            char c;
+            while ((c = (char)stream.Peek()) != -1)
+            {
+                if (c == '\\')
+                {
+                    mustInterpret = true;
+                    break;
+                }
+
+                stream.Read(); // eat the character
+                if (c == '"')
+                {
+                    complete = true;
+                    break;
+                }
+
+                builder.Append(c);
+            }
+
+            // if there are not any escape sequences--most of a JSON's strings--just
+            // return the string as-is.
+            if (!mustInterpret)
+            {
+                if (!complete)
+                    return "Could not find end of string value.";
+
+                value = StringBuilderCache.GetStringAndRelease(builder);
+                return null;
+            }
+            else
+            {
+                // NOTE: TryParseInterpretedString is responsible for releasing builder
+                // NOTE: TryParseInterpretedString assumes stream is sitting at the '\\'
+                return TryParseInterpretedString(builder, stream, out value);
+            }
+        }
+
+        private string TryParseInterpretedString(StringBuilder builder, TextReader stream, out JsonValue value)
+        {
+            // NOTE: `builder` contains the portion of the string found in `stream`, up to the first
+            //       (possible) escape sequence.
+            System.Diagnostics.Debug.Assert('\\' == (char)stream.Peek());
+
+            value = null;
+
+            string errorMessage = null;
+            bool complete = false;
+
+            int? previousHex = null;
+
+            char c;
+            while ((c = (char)stream.Peek()) != -1)
+            {
+                stream.Read(); // eat this character
+
+                if (c == '\\')
+                {
+                    // escape sequence
+                    var lookAhead = (char)stream.Peek();
+                    if (!MustInterpretComplex(lookAhead))
+                    {
+                        stream.Read(); // eat the simple escape
+                        c = InterpretSimpleEscapeSequence(lookAhead);
+                    }
+                    else
+                    {
+                        // NOTE: Currently we only handle 'u' here
+                        if (lookAhead != 'u')
+                        {
+                            StringBuilderCache.Release(builder);
+                            return $"Invalid escape sequence: '\\{lookAhead}'.";
+                        }
+
+                        var buffer = SmallBufferCache.Acquire(4);
+                        stream.Read(buffer, 0, 4);
+                        var hexString = new string(buffer);
+                        var currentHex = int.Parse(hexString, NumberStyles.HexNumber);
+
+                        if (previousHex != null)
+                        {
+                            // Our last character was \u, so combine and emit the UTF32 codepoint
+                            currentHex = ((previousHex - 0xD800) * 0x400 + (currentHex - 0xDC00) % 0x400 + 0x10000).Value;
+                            builder.Append(char.ConvertFromUtf32(currentHex));
+                            previousHex = null;
+                        }
+                        else
+                        {
+                            previousHex = currentHex;
+                        }
+
+                        SmallBufferCache.Release(buffer);
+                        continue;
+                    }
+                }
+                else if (c == '"')
+                {
+                    complete = true;
+                    break;
+                }
+
+                // Check if last character was \u, and if so emit it as-is, because
+                // this character is not a continuation of a UTF-32 escape sequence
+                if (previousHex != null)
+                {
+                    builder.Append(char.ConvertFromUtf32(previousHex.Value));
+                    previousHex = null;
+                }
+
+                // non-escape sequence
+                builder.Append(c);
+            }
+
+            // if we had a hanging UTF32 escape sequence, apply it now
+            if (previousHex != null)
+            {
+                builder.Append(char.ConvertFromUtf32(previousHex.Value));
+            }
+
+            if (!complete)
+            {
+                value = null;
+                StringBuilderCache.Release(builder);
+                return "Could not find end of string value.";
+            }
+
+            value = StringBuilderCache.GetStringAndRelease(builder);
+            return errorMessage;
+        }
+
+        /// <summary>
+        /// Indicates whether or not the lookahead character is a 
+        /// complex escape code.
+        /// </summary>
+        /// <param name="lookAhead">Lookahead character.</param>
+        /// <returns><c>true</c> if and only if <paramref name="lookAhead"/>
+        /// would require complex interpretation.</returns>
+        private static bool MustInterpretComplex(char lookAhead)
+        {
+            switch (lookAhead)
+            {
+                case '"':
+                case '/':
+                case '\\':
+                    // These escape 'as-is'
+                    return false;
+                case 'b':
+                case 'f':
+                case 'n':
+                case 'r':
+                case 't':
+                    // These escape as an escape char
+                    return false;
+
+                case 'u':
+                    // this requires more work...
+                    return true;
+
+                default:
+                    // this is an error, which our complex handler will report
+                    return true;
+            }
+        }
+
+        private static char InterpretSimpleEscapeSequence(char lookAhead)
+        {
+            switch (lookAhead)
+            {
+                case 'b':
+                    return '\b';
+                case 'f':
+                    return '\f';
+                case 'n':
+                    return '\n';
+                case 'r':
+                    return '\r';
+                case 't':
+                    return '\t';
+                default:
+                    return lookAhead;
+            }
+        }
+
+        public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			string errorMessage = null;
-			var builder = new StringBuilder();
-			stream.Read(); // waste the '"'
-			var foundEscape = false;
-			var complete = false;
-			string backup = null;
-			while (!stream.EndOfStream)
-			{
-				if (token.IsCancellationRequested)
-					return ("Parsing incomplete. The task was cancelled.", null);
-				char c;
-				if (!string.IsNullOrEmpty(backup))
-				{
-					c = backup[0];
-					backup = backup.Substring(1);
-				}
-				else
-				{
-					var result = await stream.TryRead();
-					if (!result.success) break;
-					c = result.c;
-				}
-				var append = new string(c, 1);
-				if (foundEscape)
-				{
-					switch (c)
-					{
-						case '"':
-						case '/':
-						case '\\':
-							break;
-						case 'b':
-							append = "\b";
-							break;
-						case 'f':
-							append = "\f";
-							break;
-						case 'n':
-							append = "\n";
-							break;
-						case 'r':
-							append = "\r";
-							break;
-						case 't':
-							append = "\t";
-							break;
-						case 'u':
-							var buffer = new char[4];
-							stream.Read(buffer, 0, 4);
-							var hexString = new string(buffer);
-							var hex = int.Parse(hexString, NumberStyles.HexNumber);
-							stream.Read(buffer, 0, 2);
-							backup = new string(buffer, 0, 2);
-							if (backup == "\\u")
-							{
-								stream.Read(buffer, 0, 4);
-								hexString = new string(buffer);
-								backup = null;
-								var hex2 = int.Parse(hexString, NumberStyles.HexNumber);
-								hex = (hex - 0xD800) * 0x400 + (hex2 - 0xDC00) % 0x400 + 0x10000;
-							}
-							append = char.ConvertFromUtf32(hex);
-							break;
-						default:
-							errorMessage = $"Invalid escape sequence: '\\{c}'.";
-							break;
-					}
-				}
-				else if (c == '"')
-				{
-					complete = true;
-					break;
-				}
-				foundEscape = !foundEscape && c == '\\';
-				if (!foundEscape)
-					builder.Append(append);
-			}
-			if (!complete)
-				return ("Could not find end of string value.", null);
-			var value = builder.ToString();
-			return (errorMessage, value);
+            var scratch = SmallBufferCache.Acquire(4);
+
+            await stream.TryRead(scratch, 0, 1); // waste the '"'
+
+            var builder = StringBuilderCache.Acquire();
+
+            var complete = false;
+            bool mustInterpret = false;
+            char c;
+            while ((c = (char)stream.Peek()) != -1)
+            {
+                if (c == '\\')
+                {
+                    mustInterpret = true;
+                    break;
+                }
+
+                await stream.TryRead(scratch, 0, 1); // eat the character
+                if (c == '"')
+                {
+                    complete = true;
+                    break;
+                }
+
+                builder.Append(c);
+            }
+
+            // if there are not any escape sequences--most of a JSON's strings--just
+            // return the string as-is.
+            if (!mustInterpret)
+            {
+                SmallBufferCache.Release(scratch);
+
+                string errorMessage = null;
+                JsonValue value = null;
+                if (!complete)
+                {
+                    errorMessage = "Could not find end of string value.";
+                }
+                else
+                { 
+                    value = StringBuilderCache.GetStringAndRelease(builder);
+                }
+
+                return (errorMessage, value);
+            }
+            else
+            {
+                // NOTE: TryParseInterpretedString is responsible for releasing builder
+                // NOTE: TryParseInterpretedString assumes stream is sitting at the '\\'
+                // NOTE: TryParseInterpretedString assumes scratch can hold at least 4 chars
+                return await TryParseInterpretedStringAsync(builder, stream, scratch);
+            }
 		}
-	}
+
+        private async Task<(string errorMessage, JsonValue value)> TryParseInterpretedStringAsync(StringBuilder builder, TextReader stream, char[] scratch)
+        {
+            // NOTE: `builder` contains the portion of the string found in `stream`, up to the first
+            //       (possible) escape sequence.
+            System.Diagnostics.Debug.Assert('\\' == (char)stream.Peek());
+            System.Diagnostics.Debug.Assert(scratch.Length >= 4);
+
+            bool complete = false;
+
+            int? previousHex = null;
+
+            char c;
+            while ((c = (char)stream.Peek()) != -1)
+            {
+                await stream.TryRead(scratch, 0, 1); // eat this character
+
+                if (c == '\\')
+                {
+                    // escape sequence
+                    var lookAhead = (char)stream.Peek();
+                    if (!MustInterpretComplex(lookAhead))
+                    {
+                        await stream.TryRead(scratch, 0, 1); // eat the simple escape
+                        c = InterpretSimpleEscapeSequence(lookAhead);
+                    }
+                    else
+                    {
+                        // NOTE: Currently we only handle 'u' here
+                        if (lookAhead != 'u')
+                        {
+                            StringBuilderCache.Release(builder);
+                            SmallBufferCache.Release(scratch);
+                            return ($"Invalid escape sequence: '\\{lookAhead}'.", null);
+                        }
+
+                        var charsRead = await stream.ReadAsync(scratch, 0, 4);
+                        if (charsRead < 4)
+                        {
+                            StringBuilderCache.Release(builder);
+                            SmallBufferCache.Release(scratch);
+                            return ("Could not find end of string value.", null);
+                        }
+
+                        var hexString = new string(scratch, 0, 4);
+                        var currentHex = int.Parse(hexString, NumberStyles.HexNumber);
+
+                        if (previousHex != null)
+                        {
+                            // Our last character was \u, so combine and emit the UTF32 codepoint
+                            currentHex = ((previousHex - 0xD800) * 0x400 + (currentHex - 0xDC00) % 0x400 + 0x10000).Value;
+                            builder.Append(char.ConvertFromUtf32(currentHex));
+                            previousHex = null;
+                        }
+                        else
+                        {
+                            previousHex = currentHex;
+                        }
+
+                        continue;
+                    }
+                }
+                else if (c == '"')
+                {
+                    complete = true;
+                    break;
+                }
+
+                // Check if last character was \u, and if so emit it as-is, because
+                // this character is not a continuation of a UTF-32 escape sequence
+                if (previousHex != null)
+                {
+                    builder.Append(char.ConvertFromUtf32(previousHex.Value));
+                    previousHex = null;
+                }
+
+                // non-escape sequence
+                builder.Append(c);
+            }
+
+            SmallBufferCache.Release(scratch);
+
+            // if we had a hanging UTF32 escape sequence, apply it now
+            if (previousHex != null)
+            {
+                builder.Append(char.ConvertFromUtf32(previousHex.Value));
+            }
+
+            if (!complete)
+            {
+                StringBuilderCache.Release(builder);
+                return ("Could not find end of string value.", null);
+            }
+
+            JsonValue value = StringBuilderCache.GetStringAndRelease(builder);
+            return (null, value);
+        }
+    }
 }


### PR DESCRIPTION
This PR is for review/comments only and should probably be brought in in parts, depending on the goals of the project (readability vs performance).

General strategy:
1. Reduce allocations.
2. Pool allocations.
3. Reduce LINQ usage.

BenchmarkDotNet results for the PR compared to 9.5.X and Newtonsoft.Json 10.X (read the commit messages for their individual improvements):
```
BenchmarkDotNet=v0.10.11, OS=Windows 7 SP1 (6.1.7601.0)
Processor=Intel Xeon CPU E5-2620 v3 2.40GHzIntel Xeon CPU E5-2620 v3 2.40GHz, ProcessorCount=24
Frequency=2338369 Hz, Resolution=427.6485 ns, Timer=TSC
  [Host]     : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2114.0
  DefaultJob : .NET Framework 4.7 (CLR 4.0.30319.42000), 64bit RyuJIT-v4.7.2114.0

                            Method |     Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
---------------------------------- |---------:|----------:|----------:|----------:|---------:|---------:|----------:|
 JsonSerializer_Deserialize_Stream | 38.16 ms | 0.9832 ms | 2.8990 ms | 1062.5000 | 437.5000 | 125.0000 |   5.76 MB |
                     JObject_Parse | 28.57 ms | 0.8978 ms | 2.6470 ms | 1180.0000 | 495.9375 | 159.6875 |   6.26 MB |
                     
            JsonValue_Parse_Stream | 54.46 ms | 1.7220 ms | 5.0770 ms | 4062.5000 | 625.0000 | 187.5000 |  23.54 MB |
            JsonValue_Parse_String | 42.52 ms | 1.0770 ms | 3.1740 ms | 4062.5000 | 625.0000 | 187.5000 |  23.54 MB |
              JsonValue_ParseAsync | 66.57 ms | 1.3300 ms | 3.2630 ms | 4062.5000 | 625.0000 | 187.5000 |  23.55 MB |
              
        New_JsonValue_Parse_Stream | 27.34 ms | 0.9102 ms | 2.6836 ms |  625.0000 | 312.5000 |        - |   3.96 MB |
        New_JsonValue_Parse_String | 12.49 ms | 0.2479 ms | 0.2198 ms |  687.5000 | 312.5000 |  62.5000 |   3.95 MB |
          New_JsonValue_ParseAsync | 28.94 ms | 0.7739 ms | 2.2697 ms |  656.2500 | 312.5000 |  62.5000 |   3.96 MB |
```

I also need to fix-up my whitespace to match yours.