### PR TITLE
Ensure Enum.Parse follows case sensitive flag

### DIFF
--- a/Manatee.Json/Serialization/Internal/Serializers/EnumNameSerializer.cs
+++ b/Manatee.Json/Serialization/Internal/Serializers/EnumNameSerializer.cs
@@ -38,7 +38,7 @@ namespace Manatee.Json.Serialization.Internal.Serializers
 			var entry = _descriptions[typeof (T)].FirstOrDefault(d => string.Equals(d.String, json.String, options));
 			if (entry == null)
 			{
-				return (T) Enum.Parse(typeof (T), json.String);
+				return (T) Enum.Parse(typeof (T), json.String, !serializer.Options.CaseSensitiveDeserialization);
 			}
 			return (T) entry.Value;
 		}


### PR DESCRIPTION
If there is not a `DisplayAttribute` on an enum, `Enum.Parse` does not follow the `CaseSensitiveDeserialization` flag. This adds the flag to the parse call.