### PR TITLE
Serialization performance improvements

### DIFF
--- a/Manatee.Json/Internal/StringExtensions.cs
+++ b/Manatee.Json/Internal/StringExtensions.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
@@ -11,10 +12,9 @@ namespace Manatee.Json.Internal
 {
 	internal static class StringExtensions
 	{
-		private static readonly IEnumerable<char> AvailableChars = Enumerable.Range(ushort.MinValue, ushort.MaxValue)
-																			 .Select(n => (char)n)
-																			 .Where(c => !char.IsControl(c))
-																			 .ToArray();
+		private static readonly int[] AvailableChars = Enumerable.Range(ushort.MinValue, ushort.MaxValue)
+																 .Select(n => !char.IsControl((char)n) ? n : 0)
+																 .ToArray();
 		private static readonly Regex _generalEscapePattern = new Regex("%(?<Value>[0-9A-F]{2})", RegexOptions.IgnoreCase);
 
 		public static string EvaluateEscapeSequences(this string source, out string result)
@@ -69,62 +69,74 @@ namespace Manatee.Json.Internal
 		}
 		public static string InsertEscapeSequences(this string source)
 		{
-			var index = 0;
-			while (index < source.Length)
+			for (int ii = 0; ii < source.Length; ++ii)
 			{
-				var count = 0;
-				string replace = null;
-				switch (source[index])
+				switch (source[ii])
 				{
 					case '"':
 					case '\\':
-						source = source.Insert(index, "\\");
-						index++;
-						break;
 					case '\b':
-						count = 1;
-						replace = "\\b";
-						break;
 					case '\f':
-						count = 1;
-						replace = "\\f";
-						break;
 					case '\n':
-						count = 1;
-						replace = "\\n";
-						break;
 					case '\r':
-						count = 1;
-						replace = "\\r";
-						break;
 					case '\t':
-						count = 1;
-						replace = "\\t";
-						break;
 					default:
-						if (!AvailableChars.Contains(source[index]))
+						if (AvailableChars[source[ii]] == 0)
 						{
-							var hex = Convert.ToInt16(source[index]).ToString("X4");
-							source = source.Substring(0, index) + "\\u" + hex + source.Substring(index + 1);
-							index += 5;
+							var builder = StringBuilderCache.Acquire();
+							builder.Append(source, 0, ii);
+
+							// _InsertEscapeSequencesSlow will release 'builder'
+							return _InsertEscapeSequencesSlow(source, builder, ii);
 						}
 						break;
 				}
-				if (replace != null)
-				{
-					source = _Replace(source, index, count, replace);
-					index++;
-				}
-				index++;
 			}
+
 			return source;
 		}
+		private static string _InsertEscapeSequencesSlow(string source, StringBuilder builder, int index)
+		{ 
+			for (int ii = index; ii < source.Length; ++ii)
+			{
+				switch (source[ii])
+				{
+					case '"':
+						builder.Append(@"\""");
+						break;
+					case '\\':
+						builder.Append(@"\\");
+						break;
+					case '\b':
+						builder.Append(@"\b");
+						break;
+					case '\f':
+						builder.Append(@"\f");
+						break;
+					case '\n':
+						builder.Append(@"\n");
+						break;
+					case '\r':
+						builder.Append(@"\r");
+						break;
+					case '\t':
+						builder.Append(@"\t");
+						break;
+					default:
+						if (AvailableChars[source[ii]] != 0)
+						{
+							builder.Append(source[ii]);
+						}
+						else
+						{
+							builder.Append(@"\u");
+							builder.AppendFormat("{0:X4}", source[ii]);
+						}
+						break;
+				}
+			}
 
-		private static string _Replace(string source, int index, int count, string content)
-		{
-			// I've checked both of these methods with ILSpy.  They occur in external methods, so
-			// we're not going to do much better than this.
-			return source.Remove(index, count).Insert(index, content);
+			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 		public static string SkipWhiteSpace(this string source, ref int index, int length, out char ch)
 		{

--- a/Manatee.Json/JsonArray.cs
+++ b/Manatee.Json/JsonArray.cs
@@ -37,10 +37,23 @@ namespace Manatee.Json
 		public string GetIndentedString(int indentLevel = 0)
 		{
 			if (Count == 0) return "[]";
+
+			var builder = new StringBuilder();
+
+			AppendIndentedString(builder, indentLevel);
+
+			return builder.ToString();
+		}
+		internal void AppendIndentedString(StringBuilder builder, int indentLevel)
+		{
+			if (Count == 0)
+			{
+				builder.Append("[]");
+				return;
+			}
+
 			string tab0 = string.Empty.PadLeft(indentLevel, JsonOptions.PrettyPrintIndentChar),
 				   tab1 = string.Empty.PadLeft(indentLevel + 1, JsonOptions.PrettyPrintIndentChar);
-
-			var builder = StringBuilderCache.Acquire();
 
 			builder.Append("[\n");
 			bool comma = false;
@@ -52,17 +65,15 @@ namespace Manatee.Json
 				builder.Append(tab1);
 
 				if (value != null)
-					builder.Append(value.GetIndentedString(indentLevel + 1));
+					value.AppendIndentedString(builder, indentLevel + 1);
 				else
-					builder.Append(JsonValue.Null.GetIndentedString(indentLevel + 1));
+					JsonValue.Null.AppendIndentedString(builder, indentLevel + 1);
 
 				comma = true;
 			}
 			builder.Append('\n');
 			builder.Append(tab0);
 			builder.Append(']');
-
-			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 		/// <summary>
 		/// Adds an object to the end of the <see cref="JsonArray"/>.
@@ -96,7 +107,21 @@ namespace Manatee.Json
 		{
 			if (Count == 0) return "[]";
 
-			var builder = StringBuilderCache.Acquire();
+			var builder = new StringBuilder();
+
+			AppendString(builder);
+
+			return builder.ToString();
+		}
+
+		internal void AppendString(StringBuilder builder)
+		{
+			if (Count == 0)
+			{
+				builder.Append("[]");
+				return;
+			}
+
 			builder.Append('[');
 			bool comma = false;
 			foreach (var value in this)
@@ -105,15 +130,13 @@ namespace Manatee.Json
 					builder.Append(',');
 
 				if (value != null)
-					builder.Append(value.ToString());
+					value.AppendString(builder);
 				else
-					builder.Append(JsonValue.Null.ToString());
+					JsonValue.Null.AppendString(builder);
 
 				comma = true;
 			}
 			builder.Append(']');
-
-			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 
 		/// <summary>

--- a/Manatee.Json/JsonArray.cs
+++ b/Manatee.Json/JsonArray.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Manatee.Json.Internal;
 
 namespace Manatee.Json
@@ -37,16 +38,31 @@ namespace Manatee.Json
 		{
 			if (Count == 0) return "[]";
 			string tab0 = string.Empty.PadLeft(indentLevel, JsonOptions.PrettyPrintIndentChar),
-				   tab1 = string.Empty.PadLeft(indentLevel + 1, JsonOptions.PrettyPrintIndentChar),
-				   s = "[\n";
-			int i;
-			for (i = 0; i < Count - 1; i++)
+				   tab1 = string.Empty.PadLeft(indentLevel + 1, JsonOptions.PrettyPrintIndentChar);
+
+			var builder = StringBuilderCache.Acquire();
+
+			builder.Append("[\n");
+			bool comma = false;
+			foreach (var value in this)
 			{
-				var value = this[i] ?? JsonValue.Null;
-				s += $"{tab1}{value.GetIndentedString(indentLevel + 1)},\n";
+				if (comma)
+					builder.Append(",\n");
+
+				builder.Append(tab1);
+
+				if (value != null)
+					builder.Append(value.GetIndentedString(indentLevel + 1));
+				else
+					builder.Append(JsonValue.Null.GetIndentedString(indentLevel + 1));
+
+				comma = true;
 			}
-			s += $"{tab1}{this[i].GetIndentedString(indentLevel + 1)}\n{tab0}]";
-			return s;
+			builder.Append('\n');
+			builder.Append(tab0);
+			builder.Append(']');
+
+			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 		/// <summary>
 		/// Adds an object to the end of the <see cref="JsonArray"/>.
@@ -79,7 +95,25 @@ namespace Manatee.Json
 		public override string ToString()
 		{
 			if (Count == 0) return "[]";
-			return "[" + string.Join(",", this.Select(value => value?.ToString() ?? JsonValue.Null.ToString()).ToArray()) + "]";
+
+			var builder = StringBuilderCache.Acquire();
+			builder.Append('[');
+			bool comma = false;
+			foreach (var value in this)
+			{
+				if (comma)
+					builder.Append(',');
+
+				if (value != null)
+					builder.Append(value.ToString());
+				else
+					builder.Append(JsonValue.Null.ToString());
+
+				comma = true;
+			}
+			builder.Append(']');
+
+			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 
 		/// <summary>

--- a/Manatee.Json/JsonObject.cs
+++ b/Manatee.Json/JsonObject.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Manatee.Json.Internal;
 
 namespace Manatee.Json
@@ -45,10 +46,23 @@ namespace Manatee.Json
 		public string GetIndentedString(int indentLevel = 0)
 		{
 			if (Count == 0) return "{}";
+
+			var builder = new StringBuilder();
+
+			AppendIndentedString(builder, indentLevel);
+
+			return builder.ToString();
+		}
+		internal void AppendIndentedString(StringBuilder builder, int indentLevel = 0)
+		{
+			if (Count == 0)
+			{
+				builder.Append("{}");
+				return;
+			}
+
 			string tab0 = string.Empty.PadLeft(indentLevel, JsonOptions.PrettyPrintIndentChar),
 				   tab1 = string.Empty.PadLeft(indentLevel + 1, JsonOptions.PrettyPrintIndentChar);
-
-			var builder = StringBuilderCache.Acquire();
 
 			builder.Append("{\n");
 			bool comma = false;
@@ -61,15 +75,13 @@ namespace Manatee.Json
 				builder.Append('"');
 				builder.Append(kvp.Key);
 				builder.Append("\":");
-				builder.Append(kvp.Value.GetIndentedString(indentLevel + 2));
+				kvp.Value.AppendIndentedString(builder, indentLevel + 2);
 
 				comma = true;
 			}
 			builder.Append('\n');
 			builder.Append(tab0);
 			builder.Append('}');
-
-			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 		/// <summary>
 		/// Adds the specified key and value to the dictionary.
@@ -104,7 +116,20 @@ namespace Manatee.Json
 		{
 			if (Count == 0) return "{}";
 
-			var builder = StringBuilderCache.Acquire();
+			var builder = new StringBuilder();
+
+			AppendString(builder);
+
+			return builder.ToString();
+		}
+		internal void AppendString(StringBuilder builder)
+		{
+			if (Count == 0)
+			{
+				builder.Append("{}");
+				return;
+			}
+
 			builder.Append('{');
 			bool comma = false;
 			foreach (var kvp in this)
@@ -115,13 +140,11 @@ namespace Manatee.Json
 				builder.Append('"');
 				builder.Append(kvp.Key);
 				builder.Append("\":");
-				builder.Append(kvp.Value.ToString());
+				kvp.Value.AppendString(builder);
 
 				comma = true;
 			}
 			builder.Append('}');
-
-			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 		/// <summary>
 		/// Determines whether the specified <see cref="object"/> is equal to the current <see cref="object"/>.

--- a/Manatee.Json/JsonObject.cs
+++ b/Manatee.Json/JsonObject.cs
@@ -45,19 +45,31 @@ namespace Manatee.Json
 		public string GetIndentedString(int indentLevel = 0)
 		{
 			if (Count == 0) return "{}";
-			string key, tab0 = string.Empty.PadLeft(indentLevel, JsonOptions.PrettyPrintIndentChar),
-				   tab1 = string.Empty.PadLeft(indentLevel + 1, JsonOptions.PrettyPrintIndentChar),
-				   s = "{\n";
-			int i;
-			for (i = 0; i < Count - 1; i++)
+			string tab0 = string.Empty.PadLeft(indentLevel, JsonOptions.PrettyPrintIndentChar),
+				   tab1 = string.Empty.PadLeft(indentLevel + 1, JsonOptions.PrettyPrintIndentChar);
+
+			var builder = StringBuilderCache.Acquire();
+
+			builder.Append("{\n");
+			bool comma = false;
+			foreach (var kvp in this)
 			{
-				key = Keys.ElementAt(i);
-				var value = this[key] ?? new JsonValue();
-				s += $"{tab1}\"{key}\" : {value.GetIndentedString(indentLevel + 2)},\n";
+				if (comma)
+					builder.Append(",\n");
+
+				builder.Append(tab1);
+				builder.Append('"');
+				builder.Append(kvp.Key);
+				builder.Append("\":");
+				builder.Append(kvp.Value.GetIndentedString(indentLevel + 2));
+
+				comma = true;
 			}
-			key = Keys.ElementAt(i);
-			s += $"{tab1}\"{key}\" : {this[key].GetIndentedString(indentLevel + 2)}\n{tab0}}}";
-			return s;
+			builder.Append('\n');
+			builder.Append(tab0);
+			builder.Append('}');
+
+			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 		/// <summary>
 		/// Adds the specified key and value to the dictionary.
@@ -91,7 +103,25 @@ namespace Manatee.Json
 		public override string ToString()
 		{
 			if (Count == 0) return "{}";
-			return "{" + string.Join(",", this.Select(kvp => $"\"{kvp.Key}\":{kvp.Value}").ToArray()) + "}";
+
+			var builder = StringBuilderCache.Acquire();
+			builder.Append('{');
+			bool comma = false;
+			foreach (var kvp in this)
+			{
+				if (comma)
+					builder.Append(',');
+
+				builder.Append('"');
+				builder.Append(kvp.Key);
+				builder.Append("\":");
+				builder.Append(kvp.Value.ToString());
+
+				comma = true;
+			}
+			builder.Append('}');
+
+			return StringBuilderCache.GetStringAndRelease(builder);
 		}
 		/// <summary>
 		/// Determines whether the specified <see cref="object"/> is equal to the current <see cref="object"/>.

--- a/Manatee.Json/JsonValue.cs
+++ b/Manatee.Json/JsonValue.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using Manatee.Json.Internal;
 using Manatee.Json.Parsing;
@@ -242,6 +243,21 @@ namespace Manatee.Json
 					return ToString();
 			}
 		}
+		internal void AppendIndentedString(StringBuilder builder, int indentLevel)
+		{
+			switch (Type)
+			{
+				case JsonValueType.Object:
+					_objectValue.AppendIndentedString(builder, indentLevel);
+					break;
+				case JsonValueType.Array:
+					_arrayValue.AppendIndentedString(builder, indentLevel);
+					break;
+				default:
+					AppendString(builder);
+					break;
+			}
+		}
 
 		/// <summary>
 		/// Creates a string that represents this <see cref="JsonValue"/>.
@@ -267,6 +283,32 @@ namespace Manatee.Json
 					return _arrayValue.ToString();
 				default:
 					return "null";
+			}
+		}
+		internal void AppendString(StringBuilder builder)
+		{
+			switch (Type)
+			{
+				case JsonValueType.Number:
+					builder.AppendFormat(CultureInfo.InvariantCulture, "{0}", _numberValue);
+					break;
+				case JsonValueType.String:
+					builder.Append('"');
+					_stringValue.InsertEscapeSequences(builder);
+					builder.Append('"');
+					break;
+				case JsonValueType.Boolean:
+					builder.Append(_boolValue ? "true" : "false");
+					break;
+				case JsonValueType.Object:
+					_objectValue.AppendString(builder);
+					break;
+				case JsonValueType.Array:
+					_arrayValue.AppendString(builder);
+					break;
+				default:
+					builder.Append("null");
+					break;
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/JsonValue.cs
+++ b/Manatee.Json/JsonValue.cs
@@ -258,13 +258,13 @@ namespace Manatee.Json
 				case JsonValueType.Number:
 					return string.Format(CultureInfo.InvariantCulture, "{0}", _numberValue);
 				case JsonValueType.String:
-					return $"\"{_stringValue.InsertEscapeSequences()}\"";
+					return String.Concat("\"", _stringValue.InsertEscapeSequences(), "\"");
 				case JsonValueType.Boolean:
 					return _boolValue ? "true" : "false";
 				case JsonValueType.Object:
-					return $"{_objectValue}";
+					return _objectValue.ToString();
 				case JsonValueType.Array:
-					return $"{_arrayValue}";
+					return _arrayValue.ToString();
 				default:
 					return "null";
 			}

--- a/Manatee.Json/LinqExtensions.cs
+++ b/Manatee.Json/LinqExtensions.cs
@@ -18,6 +18,9 @@ namespace Manatee.Json
 		/// <returns>An equivalent <see cref="JsonArray"/></returns>
 		public static JsonArray ToJson(this IEnumerable<JsonValue> results)
 		{
+			if (results is JsonValue[] array)
+				return new JsonArray(array);
+
 			var json = new JsonArray();
 			json.AddRange(results);
 			return json;

--- a/Manatee.Json/LinqExtensions.cs
+++ b/Manatee.Json/LinqExtensions.cs
@@ -22,7 +22,15 @@ namespace Manatee.Json
 			json.AddRange(results);
 			return json;
 		}
-
+		/// <summary>
+		/// Converts an <see cref="IDictionary{String, JsonValue}"/> into a <see cref="JsonObject"/>.
+		/// </summary>
+		/// <param name="results">An <see cref="IDictionary{String, JsonValue}"/></param>
+		/// <returns>An equivalent <see cref="JsonObject"/></returns>
+		public static JsonObject ToJson(this IDictionary<string, JsonValue> results)
+		{
+			return new JsonObject(results);
+		}
 		/// <summary>
 		/// Converts an <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{String, JsonValue}"/> returned from a
 		/// LINQ query back into a <see cref="JsonObject"/>.

--- a/Manatee.Json/Serialization/AbstractionMap.cs
+++ b/Manatee.Json/Serialization/AbstractionMap.cs
@@ -94,17 +94,22 @@ namespace Manatee.Json.Serialization
 		/// <returns>The mapped type if a mapping exists; otherwise the abstraction type.</returns>
 		public Type GetMap(Type type)
 		{
-			if (!type.GetTypeInfo().IsAbstract && !type.GetTypeInfo().IsInterface) return type;
 			if (_registry.TryGetValue(type, out Type tConcrete)) return tConcrete;
-
+			if (!type.GetTypeInfo().IsAbstract && !type.GetTypeInfo().IsInterface)
+			{
+				_registry[type] = type;
+				return type;
+			}
 			if (type.GetTypeInfo().IsGenericType)
 			{
 				var genericDefinition = type.GetGenericTypeDefinition();
-				var genericMatches = _registry.Where(t => t.Key.GetTypeInfo().IsGenericTypeDefinition && t.Key.GetGenericTypeDefinition() == genericDefinition).ToList();
-				if (genericMatches.Any())
+				foreach (var genericMatch in _registry)
 				{
-					var typeArguments = type.GetTypeArguments();
-					return genericMatches.First().Value.MakeGenericType(typeArguments);
+					if (genericMatch.Key.GetTypeInfo().IsGenericTypeDefinition && genericMatch.Key.GetGenericTypeDefinition() == genericDefinition)
+					{
+						var typeArguments = type.GetTypeArguments();
+						return genericMatch.Value.MakeGenericType(typeArguments);
+					}
 				}
 			}
 			return type;
@@ -113,30 +118,43 @@ namespace Manatee.Json.Serialization
 		internal T CreateInstance<T>(JsonValue json, IResolver resolver)
 		{
 			var type = typeof (T);
-			if (type.GetTypeInfo().IsAbstract || type.GetTypeInfo().IsInterface || type.GetTypeInfo().IsGenericType)
+			var resolveSlow = type.GetTypeInfo().IsAbstract || type.GetTypeInfo().IsInterface || type.GetTypeInfo().IsGenericType;
+			if (!resolveSlow)
 			{
-				if ((json != null) && (json.Type == JsonValueType.Object) && (json.Object.ContainsKey(Constants.TypeKey)))
-				{
-					var concrete = Type.GetType(json.Object[Constants.TypeKey].String);
-					return (T) resolver.Resolve(concrete);
-				}
-				if (!_registry.TryGetValue(type, out Type tConcrete))
-				{
-					if (type.GetTypeInfo().IsGenericType)
-						type = type.GetGenericTypeDefinition();
-					_registry.TryGetValue(type, out tConcrete);
-				}
-
-				if (tConcrete != null)
-				{
-					if (tConcrete.GetTypeInfo().IsGenericTypeDefinition)
-						tConcrete = tConcrete.MakeGenericType(typeof(T).GetTypeArguments());
-					return (T) resolver.Resolve(tConcrete);
-				}
-
-				if (type.GetTypeInfo().IsInterface)
-					return TypeGenerator.Generate<T>();
+				return resolver.Resolve<T>();
 			}
+			else
+			{
+				return _ResolveSlow<T>(json, resolver);
+			}
+		}
+
+		private T _ResolveSlow<T>(JsonValue json, IResolver resolver)
+		{
+			if ((json != null) && (json.Type == JsonValueType.Object) && (json.Object.ContainsKey(Constants.TypeKey)))
+			{
+				var concrete = Type.GetType(json.Object[Constants.TypeKey].String);
+				return (T)resolver.Resolve(concrete);
+			}
+
+			var type = typeof(T);
+			if (!_registry.TryGetValue(type, out Type tConcrete))
+			{
+				if (type.GetTypeInfo().IsGenericType)
+					type = type.GetGenericTypeDefinition();
+				_registry.TryGetValue(type, out tConcrete);
+			}
+
+			if (tConcrete != null)
+			{
+				if (tConcrete.GetTypeInfo().IsGenericTypeDefinition)
+					tConcrete = tConcrete.MakeGenericType(typeof(T).GetTypeArguments());
+				return (T)resolver.Resolve(tConcrete);
+			}
+
+			if (type.GetTypeInfo().IsInterface)
+				return TypeGenerator.Generate<T>();
+
 			return resolver.Resolve<T>();
 		}
 

--- a/Manatee.Json/Serialization/Internal/AutoRegistration/ArraySerializationDelegateProvider.cs
+++ b/Manatee.Json/Serialization/Internal/AutoRegistration/ArraySerializationDelegateProvider.cs
@@ -18,15 +18,22 @@ namespace Manatee.Json.Serialization.Internal.AutoRegistration
 
 		private static JsonValue _Encode<T>(T[] array, JsonSerializer serializer)
 		{
-			var json = new JsonArray();
-			json.AddRange(array.Select(serializer.Serialize));
-			return json;
+			var values = new JsonValue[array.Length];
+			for (int ii = 0; ii < array.Length; ++ii)
+			{
+				values[ii] = serializer.Serialize(array[ii]);
+			}
+			return new JsonArray(values);
 		}
 		private static T[] _Decode<T>(JsonValue json, JsonSerializer serializer)
 		{
-			var list = new List<T>();
-			list.AddRange(json.Array.Select(serializer.Deserialize<T>));
-			return list.ToArray();
+			var array = json.Array;
+			var values = new T[array.Count];
+			for (int ii = 0; ii < array.Count; ++ii)
+			{
+				values[ii] = serializer.Deserialize<T>(array[ii]);
+			}
+			return values;
 		}
 	}
 }

--- a/Manatee.Json/Serialization/Internal/AutoRegistration/DictionarySerializationDelegateProvider.cs
+++ b/Manatee.Json/Serialization/Internal/AutoRegistration/DictionarySerializationDelegateProvider.cs
@@ -17,58 +17,85 @@ namespace Manatee.Json.Serialization.Internal.AutoRegistration
 
 		private static JsonValue _Encode<TKey, TValue>(Dictionary<TKey, TValue> dict, JsonSerializer serializer)
 		{
-			if (typeof(Enum).GetTypeInfo().IsAssignableFrom(typeof(TKey).GetTypeInfo()))
-				return dict.ToDictionary(kvp =>
-					                         {
-						                         var encodeDefaults = serializer.Options.EncodeDefaultValues;
-						                         serializer.Options.EncodeDefaultValues = true;
-						                         var enumFormat = serializer.Options.EnumSerializationFormat;
-						                         serializer.Options.EnumSerializationFormat = EnumSerializationFormat.AsName;
-
-						                         var key = serializer.Options.SerializationNameTransform(serializer.Serialize(kvp.Key).String);
-
-						                         serializer.Options.EnumSerializationFormat = enumFormat;
-						                         serializer.Options.EncodeDefaultValues = encodeDefaults;
-
-						                         return key;
-					                         },
-				                         kvp => serializer.Serialize(kvp.Value)).ToJson();
-
 			if (typeof(TKey) == typeof(string))
-				return dict.ToDictionary(kvp => (string) (object) kvp.Key, kvp => serializer.Serialize(kvp.Value)).ToJson();
-
-			var array = new JsonArray();
-			array.AddRange(dict.Select(item => (JsonValue) new JsonObject
+			{
+				var output = new Dictionary<string, JsonValue>();
+				foreach (var kvp in dict)
 				{
-					{"Key", serializer.Serialize(item.Key)},
-					{"Value", serializer.Serialize(item.Value)}
-				}));
-			return array;
+					output.Add((string)(object)kvp.Key, serializer.Serialize(kvp.Value));
+				}
+
+				return output.ToJson();
+			}
+
+			if (typeof(Enum).GetTypeInfo().IsAssignableFrom(typeof(TKey).GetTypeInfo()))
+				return _EncodeEnumKeyDictionary(dict, serializer);
+
+			return _EncodeDictionary(dict, serializer);
+		}
+		private static JsonValue _EncodeDictionary<TKey, TValue>(Dictionary<TKey, TValue> dict, JsonSerializer serializer)
+		{
+			var array = new JsonValue[dict.Count];
+			int ii = 0;
+			foreach (var item in dict)
+			{
+				array[ii] = new JsonObject
+				{
+					{ "Key", serializer.Serialize(item.Key) },
+					{ "Value", serializer.Serialize(item.Value) },
+				};
+			}
+			return new JsonArray(array);
+		}
+		private static JsonValue _EncodeEnumKeyDictionary<TKey, TValue>(Dictionary<TKey, TValue> dict, JsonSerializer serializer)
+		{
+			var encodeDefaults = serializer.Options.EncodeDefaultValues;
+			serializer.Options.EncodeDefaultValues = true;
+			var enumFormat = serializer.Options.EnumSerializationFormat;
+			serializer.Options.EnumSerializationFormat = EnumSerializationFormat.AsName;
+
+			var output = new Dictionary<string, JsonValue>();
+			foreach (var kvp in dict)
+			{
+				var key = serializer.Options.SerializationNameTransform(serializer.Serialize(kvp.Key).String);
+				output.Add(key, serializer.Serialize(kvp.Value));
+			}
+
+			serializer.Options.EnumSerializationFormat = enumFormat;
+			serializer.Options.EncodeDefaultValues = encodeDefaults;
+
+			return output.ToJson();
 		}
 		private static Dictionary<TKey, TValue> _Decode<TKey, TValue>(JsonValue json, JsonSerializer serializer)
 		{
-			if (typeof(Enum).GetTypeInfo().IsAssignableFrom(typeof(TKey).GetTypeInfo()))
-				return json.Object.ToDictionary(kvp =>
-					                                {
-						                                var encodeDefaults = serializer.Options.EncodeDefaultValues;
-						                                serializer.Options.EncodeDefaultValues = true;
-						                                var enumFormat = serializer.Options.EnumSerializationFormat;
-						                                serializer.Options.EnumSerializationFormat = EnumSerializationFormat.AsName;
-
-						                                var key = serializer.Deserialize<TKey>(serializer.Options.DeserializationNameTransform(kvp.Key));
-
-						                                serializer.Options.EnumSerializationFormat = enumFormat;
-						                                serializer.Options.EncodeDefaultValues = encodeDefaults;
-						                                return key;
-					                                },
-				                                kvp => serializer.Deserialize<TValue>(kvp.Value));
-
 			if (typeof(TKey) == typeof(string))
-				return json.Object.ToDictionary(kvp => (TKey) (object) kvp.Key,
-				                                kvp => serializer.Deserialize<TValue>(kvp.Value));
+				return json.Object.ToDictionary(kvp => (TKey)(object)kvp.Key,
+												kvp => serializer.Deserialize<TValue>(kvp.Value));
+
+			if (typeof(Enum).GetTypeInfo().IsAssignableFrom(typeof(TKey).GetTypeInfo()))
+				return _DecodeEnumDictionary<TKey, TValue>(json, serializer);
 
 			return json.Array.ToDictionary(jv => serializer.Deserialize<TKey>(jv.Object["Key"]),
 			                               jv => serializer.Deserialize<TValue>(jv.Object["Value"]));
+		}
+		private static Dictionary<TKey, TValue> _DecodeEnumDictionary<TKey, TValue>(JsonValue json, JsonSerializer serializer)
+		{
+			var encodeDefaults = serializer.Options.EncodeDefaultValues;
+			serializer.Options.EncodeDefaultValues = true;
+			var enumFormat = serializer.Options.EnumSerializationFormat;
+			serializer.Options.EnumSerializationFormat = EnumSerializationFormat.AsName;
+
+			var output = new Dictionary<TKey, TValue>();
+			foreach (var kvp in json.Object)
+			{
+				var key = serializer.Deserialize<TKey>(serializer.Options.DeserializationNameTransform(kvp.Key));
+				output.Add(key, serializer.Deserialize<TValue>(kvp.Value));
+			}
+
+			serializer.Options.EnumSerializationFormat = enumFormat;
+			serializer.Options.EncodeDefaultValues = encodeDefaults;
+
+			return output;
 		}
 	}
 }

--- a/Manatee.Json/Serialization/Internal/AutoRegistration/ListSerializationDelegateProvider.cs
+++ b/Manatee.Json/Serialization/Internal/AutoRegistration/ListSerializationDelegateProvider.cs
@@ -14,14 +14,21 @@ namespace Manatee.Json.Serialization.Internal.AutoRegistration
 
 		private static JsonValue _Encode<T>(List<T> list, JsonSerializer serializer)
 		{
-			var array = new JsonArray();
-			array.AddRange(list.Select(serializer.Serialize));
-			return array;
+			var array = new JsonValue[list.Count];
+			for (int ii = 0; ii < array.Length; ++ii)
+			{
+				array[ii] = serializer.Serialize(list[ii]);
+			}
+			return new JsonArray(array);
 		}
 		private static List<T> _Decode<T>(JsonValue json, JsonSerializer serializer)
 		{
-			var list = new List<T>();
-			list.AddRange(json.Array.Select(serializer.Deserialize<T>));
+			var array = json.Array;
+			var list = new List<T>(array.Count);
+			for (int ii = 0; ii < array.Count; ++ii)
+			{
+				list.Add(serializer.Deserialize<T>(array[ii]));
+			}
 			return list;
 		}
 	}

--- a/Manatee.Json/Serialization/Internal/AutoRegistration/StackSerializationDelegateProvider.cs
+++ b/Manatee.Json/Serialization/Internal/AutoRegistration/StackSerializationDelegateProvider.cs
@@ -14,21 +14,22 @@ namespace Manatee.Json.Serialization.Internal.AutoRegistration
 
 		private static JsonValue _Encode<T>(Stack<T> stack, JsonSerializer serializer)
 		{
-			var array = new JsonArray();
-			for (int i = 0; i < stack.Count; i++)
+			var values = new JsonValue[stack.Count];
+			for (int i = 0; i < values.Length; i++)
 			{
-				array.Add(serializer.Serialize(stack.ElementAt(i)));
+				values[0] = serializer.Serialize(stack.ElementAt(i));
 			}
-			return array;
+			return new JsonArray(values);
 		}
 		private static Stack<T> _Decode<T>(JsonValue json, JsonSerializer serializer)
 		{
-			var stack = new Stack<T>();
-			for (int i = 0; i < json.Array.Count; i++)
+			var array = json.Array;
+			var values = new T[array.Count];
+			for (int i = 0; i < values.Length; i++)
 			{
-				stack.Push(serializer.Deserialize<T>(json.Array[i]));
+				values[i] = serializer.Deserialize<T>(array[i]);
 			}
-			return stack;
+			return new Stack<T>(values);
 		}
 	}
 }

--- a/Manatee.Json/Serialization/Internal/SerializationPairCache.cs
+++ b/Manatee.Json/Serialization/Internal/SerializationPairCache.cs
@@ -1,50 +1,50 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Manatee.Json.Serialization.Internal
 {
 	internal class SerializationPairCache
 	{
-		private IDictionary<Guid, SerializationPair> map = new Dictionary<Guid, SerializationPair>();
-		private IDictionary<SerializationPair, Guid> reverse = new Dictionary<SerializationPair, Guid>();
+		private IDictionary<object, SerializationPair> _objMap = new Dictionary<object, SerializationPair>();
+		private IDictionary<Guid, SerializationPair> _guidMap = new Dictionary<Guid, SerializationPair>();
+		private IDictionary<SerializationPair, Guid> _reverse = new Dictionary<SerializationPair, Guid>();
 
 		public SerializationPair this[Guid key]
 		{
 			get
 			{
-				return map[key];
+				return _guidMap[key];
 			}
 			set
 			{
-				map[key] = value;
-				reverse[value] = key;
+				throw new NotSupportedException();
 			}
 		}
 
-		public int Count => map.Count;
+		public int Count => _guidMap.Count;
 
 		public void Add(Guid key, SerializationPair value)
 		{
-			map.Add(key, value);
-			reverse.Add(value, key);
+			Debug.Assert(value.Object != null);
+			_objMap.Add(value.Object, value);
+			_guidMap.Add(key, value);
+			_reverse.Add(value, key);
 		}
 
 		public void Clear()
 		{
-			map.Clear();
-			reverse.Clear();
+			_objMap.Clear();
+			_guidMap.Clear();
+			_reverse.Clear();
 		}
 
 		public bool TryGetPair(object obj, out Guid key, out SerializationPair pair)
 		{
-			foreach (var value in map.Values)
+			if (_objMap.TryGetValue(obj, out pair))
 			{
-				if (ReferenceEquals(value.Object, obj))
-				{
-					key = reverse[value];
-					pair = value;
-					return true;
-				}
+				key = _reverse[pair];
+				return true;
 			}
 
 			key = default(Guid);

--- a/Manatee.Json/Serialization/Internal/SerializationPairCache.cs
+++ b/Manatee.Json/Serialization/Internal/SerializationPairCache.cs
@@ -1,18 +1,55 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Manatee.Json.Serialization.Internal
 {
-	internal class SerializationPairCache : Dictionary<Guid, SerializationPair>
+	internal class SerializationPairCache
 	{
-		public bool Contains(object obj)
+		private IDictionary<Guid, SerializationPair> map = new Dictionary<Guid, SerializationPair>();
+		private IDictionary<SerializationPair, Guid> reverse = new Dictionary<SerializationPair, Guid>();
+
+		public SerializationPair this[Guid key]
 		{
-			return Values.Any(v => ReferenceEquals(v.Object, obj));
+			get
+			{
+				return map[key];
+			}
+			set
+			{
+				map[key] = value;
+				reverse[value] = key;
+			}
 		}
-		public Guid GetKey(object obj)
+
+		public int Count => map.Count;
+
+		public void Add(Guid key, SerializationPair value)
 		{
-			return this.First(v => ReferenceEquals(v.Value.Object, obj)).Key;
+			map.Add(key, value);
+			reverse.Add(value, key);
+		}
+
+		public void Clear()
+		{
+			map.Clear();
+			reverse.Clear();
+		}
+
+		public bool TryGetPair(object obj, out Guid key, out SerializationPair pair)
+		{
+			foreach (var value in map.Values)
+			{
+				if (ReferenceEquals(value.Object, obj))
+				{
+					key = reverse[value];
+					pair = value;
+					return true;
+				}
+			}
+
+			key = default(Guid);
+			pair = null;
+			return false;
 		}
 	}
 }

--- a/Manatee.Json/Serialization/Internal/SerializerCache.cs
+++ b/Manatee.Json/Serialization/Internal/SerializerCache.cs
@@ -13,13 +13,13 @@ namespace Manatee.Json.Serialization.Internal
 			_cache = new Dictionary<Type, SerializerMethodPair>();
 		}
 
-		public static MethodInfo GetSerializeMethod(Type type)
+		public static Func<JsonSerializer, object, object> GetSerializeMethod(Type type)
 		{
 			var pair = _EnsureMethodPair(type);
 			return pair.Serializer;
 		}
 
-		public static MethodInfo GetDeserializeMethod(Type type)
+		public static Func<JsonSerializer, object, object> GetDeserializeMethod(Type type)
 		{
 			var pair = _EnsureMethodPair(type);
 			return pair.Deserializer;

--- a/Manatee.Json/Serialization/Internal/SerializerMethodPair.cs
+++ b/Manatee.Json/Serialization/Internal/SerializerMethodPair.cs
@@ -5,24 +5,62 @@ namespace Manatee.Json.Serialization.Internal
 {
 	internal class SerializerMethodPair
 	{
-		public MethodInfo Serializer { get; }
-		public MethodInfo Deserializer { get; }
+		public Func<JsonSerializer, object, object> Serializer { get; }
+
+		public Func<JsonSerializer, object, object> Deserializer { get; }
 
 		public SerializerMethodPair(Type type)
 		{
-			Serializer = _GetTypedSerializeMethod(type);
-			Deserializer = _GetTypedDeserializeMethod(type);
+			Serializer = _MakeTypedSerializer(type);
+			Deserializer = _MakeTypedDeserializer(type);
 		}
 
+		private static Func<JsonSerializer, object, object> _MakeTypedSerializer(Type type)
+		{
+			var serializer = _GetTypedSerializeMethod(type);
+			return _MakeDelegate<JsonSerializer>(serializer);
+		}
+		private static Func<JsonSerializer, object, object> _MakeTypedDeserializer(Type type)
+		{
+			var deserializer = _GetTypedDeserializeMethod(type);
+			return _MakeDelegate<JsonSerializer>(deserializer);
+		}
 		private static MethodInfo _GetTypedSerializeMethod(Type type)
 		{
-			return typeof(JsonSerializer).GetTypeInfo().GetDeclaredMethod("Serialize")
+			return typeof(JsonSerializer).GetTypeInfo().GetDeclaredMethod(nameof(JsonSerializer.Serialize))
 										 .MakeGenericMethod(type);
 		}
 		private static MethodInfo _GetTypedDeserializeMethod(Type type)
 		{
-			return typeof(JsonSerializer).GetTypeInfo().GetDeclaredMethod("Deserialize")
+			return typeof(JsonSerializer).GetTypeInfo().GetDeclaredMethod(nameof(JsonSerializer.Deserialize))
 										 .MakeGenericMethod(type);
+		}
+		// adapted from: https://codeblog.jonskeet.uk/2008/08/09/making-reflection-fly-and-exploring-delegates/
+		private static Func<TInstance, object, object> _MakeDelegate<TInstance>(MethodInfo methodInfo)
+		{
+			var helper = typeof(SerializerMethodPair).GetTypeInfo()
+													 .GetDeclaredMethod(nameof(_MakeDelegateHelper));
+
+			// Get a concrete instance of our helper method
+			var realHelper = helper.MakeGenericMethod(
+				typeof(TInstance),
+				methodInfo.GetParameters()[0].ParameterType,
+				methodInfo.ReturnType);
+
+			// Apply the helper method to our method
+			var method = realHelper.Invoke(null, new object[] { methodInfo });
+
+			return (Func<TInstance, object, object>)method;
+		}
+		private static Func<TInstance, object, object> _MakeDelegateHelper<TInstance, TParam, TReturn>(MethodInfo methodInfo)
+			where TInstance : class
+		{
+			Func<TInstance, TParam, TReturn> method
+				= (Func<TInstance, TParam, TReturn>)methodInfo.CreateDelegate(typeof(Func<TInstance, TParam, TReturn>));
+
+			Func<TInstance, object, object> methodCaller
+				= (TInstance instance, object param) => method(instance, (TParam)param);
+			return methodCaller;
 		}
 	}
 }

--- a/Manatee.Json/Serialization/Internal/Serializers/AutoSerializer.cs
+++ b/Manatee.Json/Serialization/Internal/Serializers/AutoSerializer.cs
@@ -145,7 +145,9 @@ namespace Manatee.Json.Serialization.Internal.Serializers
 				if (memberInfo.ShouldTransform)
 					name = serializer.Options.DeserializationNameTransform(name);
 
-				if (_TryGetKeyValue(json, name, ignoreCase, out var value))
+				var visited = new HashSet<string>(ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+				if (_TryGetKeyValue(json, name, ignoreCase, out var value)
+				 && visited.Add(name))
 				{
 					Func<JsonSerializer, JsonValue, object> deserialize;
 					if (memberInfo.MemberInfo is PropertyInfo info)
@@ -170,7 +172,6 @@ namespace Manatee.Json.Serialization.Internal.Serializers
 					}
 					else
 						dict.Add(memberInfo, valueObj);
-					json.Object.Remove(name);
 				}
 			}
 			return dict;
@@ -182,7 +183,9 @@ namespace Manatee.Json.Serialization.Internal.Serializers
 			{
 				var name = memberInfo.SerializationName;
 
-				if (_TryGetKeyValue(json, name, ignoreCase, out var value))
+				var visited = new HashSet<string>(ignoreCase ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal);
+				if (_TryGetKeyValue(json, name, ignoreCase, out var value)
+				 && visited.Add(name))
 				{
 					Func<JsonSerializer, JsonValue, object> deserialize;
 					if (memberInfo.MemberInfo is PropertyInfo)
@@ -207,7 +210,6 @@ namespace Manatee.Json.Serialization.Internal.Serializers
 					}
 					else
 						dict.Add(memberInfo, valueObj);
-					json.Object.Remove(name);
 				}
 			}
 			return dict;
@@ -231,12 +233,12 @@ namespace Manatee.Json.Serialization.Internal.Serializers
 					{
 						if (string.Compare(kvp.Key, name, StringComparison.OrdinalIgnoreCase) != 0) continue;
 
-						key = kvp.Key;
-						value = kvp.Value;
-						break;
+							key = kvp.Key;
+							value = kvp.Value;
+							break;
+						}
 					}
 				}
-			}
 
 			return key != null;
 		}

--- a/Manatee.Json/Serialization/Internal/Serializers/ReferencingSerializer.cs
+++ b/Manatee.Json/Serialization/Internal/Serializers/ReferencingSerializer.cs
@@ -15,17 +15,17 @@ namespace Manatee.Json.Serialization.Internal.Serializers
 
 		public JsonValue Serialize<T>(T obj, JsonSerializer serializer)
 		{
+			Guid guid;
 			SerializationPair pair;
-			if (serializer.SerializationMap.Contains(obj))
+			if (serializer.SerializationMap.TryGetPair(obj, out guid, out pair))
 			{
-				var guid = serializer.SerializationMap.GetKey(obj);
 				pair = serializer.SerializationMap[guid];
 				pair.UsageCount++;
 				return new JsonObject {{Constants.RefKey, guid.ToString()}};
 			}
 			if (_innerSerializer.ShouldMaintainReferences)
 			{
-				var guid = Guid.NewGuid();
+				guid = Guid.NewGuid();
 				pair = new SerializationPair {Object = obj};
 				serializer.SerializationMap.Add(guid, pair);
 				pair.Json = _innerSerializer.Serialize(obj, serializer);

--- a/Manatee.Json/Serialization/Internal/Serializers/ReflectionCache.cs
+++ b/Manatee.Json/Serialization/Internal/Serializers/ReflectionCache.cs
@@ -34,32 +34,32 @@ namespace Manatee.Json.Serialization.Internal.Serializers
 		public static IEnumerable<SerializationInfo> GetMembers(Type type, PropertySelectionStrategy propertyTypes, bool includeFields)
 		{
 			var info = _InitializeInstanceCache(type);
-			var members = _GetProperties(info, propertyTypes);
+			var members = new List<SerializationInfo>();
+			_GetProperties(info, propertyTypes, members);
 			if (includeFields)
-				members = members.Concat(_GetFields(info));
+				_GetFields(info, members);
 			return members;
 		}
 		public static IEnumerable<SerializationInfo> GetTypeMembers(Type type, PropertySelectionStrategy propertyTypes, bool includeFields)
 		{
 			var info = _InitializeStaticCache(type);
-			var members = _GetProperties(info, propertyTypes);
+			var members = new List<SerializationInfo>();
+			_GetProperties(info, propertyTypes, members);
 			if (includeFields)
-				members = members.Concat(_GetFields(info));
+				_GetFields(info, members);
 			return members;
 		}
 
-		private static IEnumerable<SerializationInfo> _GetProperties(ReflectionInfo info, PropertySelectionStrategy propertyTypes)
+		private static IEnumerable<SerializationInfo> _GetProperties(ReflectionInfo info, PropertySelectionStrategy propertyTypes, List<SerializationInfo> properties)
 		{
-			var properties = new List<SerializationInfo>();
 			if (propertyTypes.HasFlag(PropertySelectionStrategy.ReadWriteOnly))
 				properties.AddRange(info.ReadWriteProperties);
 			if (propertyTypes.HasFlag(PropertySelectionStrategy.ReadOnly))
 				properties.AddRange(info.ReadOnlyProperties);
 			return properties;
 		}
-		private static IEnumerable<SerializationInfo> _GetFields(ReflectionInfo info)
+		private static IEnumerable<SerializationInfo> _GetFields(ReflectionInfo info, List<SerializationInfo> fields)
 		{
-			var fields = new List<SerializationInfo>();
 			fields.AddRange(info.Fields);
 			return fields;
 		}


### PR DESCRIPTION
Various serialization performance improvements (and some deserialization improvements).

- Remove excess allocations in the `JsonValue.ToString` code path
  - Adds new internal `AppendString` and `AppendIndentedString` methods to use an existing `StringBuilder`
- Refactor `InsertEscapeSequences` to use a `StringBuilder` (if necessary)
- Removed LINQ on hot path in `AbstractionMap`
- Removed LINQ on hot path in `CustomSerializations`
- Removed LINQ from and decreased allocations in auto serializers/deserializers
- `SerializationPairCache` now tracks the object itself. **This should be scrutinized to ensure it does not leak.**
- `SerializerMethodPair` now builds `Func<>`'s instead of using `MemberInfo.Invoke`
- Removed LINQ on hot path in `AutoSerializer`
  - Also fixed a bug (?) where the input `JsonObject` was mutated, switched to a set which tracks visited properties instead. **This should be scrutinized as it seems to change existing behavior, but may be a bug.**
- Removed LINQ on hot path in `ReflectionCache`

Manatee 9.5.1 vs Json.NET 10.X:
```
                               Method |      Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |   Gen 2 | Allocated |
------------------------------------- |----------:|----------:|----------:|----------:|---------:|--------:|----------:|
           JsonNET_JObject_FromObject |  23.67 ms | 0.8877 ms |  2.617 ms |  906.2500 | 375.0000 | 93.7500 |   5.05 MB |
     Manatee_JsonSerializer_Serialize | 241.50 ms | 7.8860 ms | 23.250 ms | 1312.5000 | 250.0000 | 62.5000 |   7.92 MB |
 New_Manatee_JsonSerializer_Serialize |  28.60 ms | 1.3421 ms |  3.957 ms |  687.5000 | 250.0000 |       - |   4.47 MB |
```
Approximate 8.4x speedup, 1.8x reduction in memory allocated along the `Serialize` path.

```
                         Method |     Mean |     Error |    StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
------------------------------- |---------:|----------:|----------:|---------:|---------:|---------:|----------:|
       JsonNET_JObject_ToString | 6.890 ms | 0.1592 ms | 0.4694 ms | 445.0000 | 304.3750 | 163.7500 |    2.9 MB |
 New_Manatee_JsonValue_ToString | 1.100 ms | 0.0209 ms | 0.0529 ms |  46.8884 |  29.0293 |  20.5212 | 293.48 KB |
```
Difference in speed from 9.5.1 is too great to measure (takes ~10s/op), but basically 10 s to 1.1 ms!