### PR TITLE
Fix StringParser Pex failures

### DIFF
--- a/Manatee.Json.Tests/JsonValueParseTest.cs
+++ b/Manatee.Json.Tests/JsonValueParseTest.cs
@@ -208,5 +208,14 @@ namespace Manatee.Json.Tests
 			var json = JsonValue.Parse(str);
 			Console.WriteLine(json);
 		}
+		[Test]
+		public void Parse_InvalidUtf32Code()
+		{
+			// Found during Pex testing of StringParser.TryParse
+
+			// Message: System.ArgumentOutOfRangeException : A valid UTF32 value is between 0x000000 and 0x10ffff,
+			// inclusive, and should not include surrogate codepoint values(0x00d800 ~0x00dfff).
+			var json = JsonValue.Parse("\"\\uA000\\uA000\"");
+		}
 	}
 }

--- a/Manatee.Json/Internal/StringExtensions.cs
+++ b/Manatee.Json/Internal/StringExtensions.cs
@@ -172,15 +172,18 @@ namespace Manatee.Json.Internal
 
 		public static string SkipWhiteSpace(this TextReader stream, out char ch)
 		{
-			ch = (char)stream.Peek();
-			while (ch != -1)
+			ch = default(char);
+
+			int c = stream.Peek();
+			while (c != -1)
 			{
+				ch = (char)c;
 				if (!char.IsWhiteSpace(ch)) break;
 				stream.Read();
-				ch = (char)stream.Peek();
+				c = stream.Peek();
 			}
 
-			if (ch == -1)
+			if (c == -1)
 			{
 				ch = default(char);
 				return "Unexpected end of input.";
@@ -192,15 +195,17 @@ namespace Manatee.Json.Internal
 		public static async Task<(string, char)> SkipWhiteSpaceAsync(this TextReader stream, char[] scratch)
 		{
 			System.Diagnostics.Debug.Assert(scratch.Length >= 1);
-			char ch;
-			ch = (char)stream.Peek();
-			while (ch != -1)
+			char ch = default(char);
+			int c = stream.Peek();
+			while (c != -1)
 			{
+				ch = (char)c;
 				if (!char.IsWhiteSpace(ch)) break;
 				await stream.ReadAsync(scratch, 0, 1);
-				ch = (char)stream.Peek();
+				c = stream.Peek();
 			}
-			if (ch == -1)
+
+			if (c == -1)
 			{
 				ch = default(char);
 				return ("Unexpected end of input.", ch);

--- a/Manatee.Json/Parsing/ArrayParser.cs
+++ b/Manatee.Json/Parsing/ArrayParser.cs
@@ -16,10 +16,10 @@ namespace Manatee.Json.Parsing
 		{
 			System.Diagnostics.Debug.Assert(index < source.Length && source[index] == '[');
 
-			bool complete = false;
+			value = null;
 
+			bool complete = false;
 			var array = new JsonArray();
-			value = array;
 			var length = source.Length;
 			index++;
 			while (index < length)
@@ -54,15 +54,17 @@ namespace Manatee.Json.Parsing
 			if (!complete)
 				return "Unterminated array (missing ']')";
 
+			value = array;
 			return null;
 		}
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
 			System.Diagnostics.Debug.Assert(stream.Peek() == '[');
 
+			value = null;
+
 			bool complete = false;
 			var array = new JsonArray();
-			value = array;
 			while (stream.Peek() != -1)
 			{
 				stream.Read(); // waste the '[' or ','
@@ -96,6 +98,7 @@ namespace Manatee.Json.Parsing
 			if (!complete)
 				return "Unterminated array (missing ']')";
 
+			value = array;
 			return null;
 		}
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)

--- a/Manatee.Json/Parsing/ArrayParser.cs
+++ b/Manatee.Json/Parsing/ArrayParser.cs
@@ -14,9 +14,6 @@ namespace Manatee.Json.Parsing
 		}
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			if (source == null)
-				throw new ArgumentNullException(nameof(source));
-
 			System.Diagnostics.Debug.Assert(index < source.Length && source[index] == '[');
 
 			bool complete = false;
@@ -61,9 +58,6 @@ namespace Manatee.Json.Parsing
 		}
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			System.Diagnostics.Debug.Assert(stream.Peek() == '[');
 
 			bool complete = false;
@@ -106,9 +100,6 @@ namespace Manatee.Json.Parsing
 		}
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			System.Diagnostics.Debug.Assert(stream.Peek() == '[');
 
 			var scratch = SmallBufferCache.Acquire(1);

--- a/Manatee.Json/Parsing/BoolParser.cs
+++ b/Manatee.Json/Parsing/BoolParser.cs
@@ -17,8 +17,6 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			if (source == null)
-				throw new ArgumentNullException(nameof(source));
 			if (index >= source.Length)
 				throw new ArgumentOutOfRangeException(nameof(index));
 
@@ -52,9 +50,6 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			value = null;
 
 			int count;
@@ -101,9 +96,6 @@ namespace Manatee.Json.Parsing
 
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			var buffer = SmallBufferCache.Acquire(5);
 			var count = await stream.ReadAsync(buffer, 0, 4);
 			if (count < 4)

--- a/Manatee.Json/Parsing/BoolParser.cs
+++ b/Manatee.Json/Parsing/BoolParser.cs
@@ -17,6 +17,11 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
+			if (source == null)
+				throw new ArgumentNullException(nameof(source));
+			if (index >= source.Length)
+				throw new ArgumentOutOfRangeException(nameof(index));
+
 			value = null;
 
 			if (source[index] == 't' || source[index] == 'T')
@@ -47,6 +52,9 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
+			if (stream == null)
+				throw new ArgumentNullException(nameof(stream));
+
 			value = null;
 
 			int count;
@@ -93,6 +101,9 @@ namespace Manatee.Json.Parsing
 
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
+			if (stream == null)
+				throw new ArgumentNullException(nameof(stream));
+
 			var buffer = SmallBufferCache.Acquire(5);
 			var count = await stream.ReadAsync(buffer, 0, 4);
 			if (count < 4)

--- a/Manatee.Json/Parsing/NullParser.cs
+++ b/Manatee.Json/Parsing/NullParser.cs
@@ -17,9 +17,6 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			if (source == null)
-				throw new ArgumentNullException(nameof(source));
-
 			value = null;
 
 			if (index + 4 > source.Length)
@@ -35,9 +32,6 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			value = null;
 
 			var buffer = SmallBufferCache.Acquire(4);
@@ -62,9 +56,6 @@ namespace Manatee.Json.Parsing
 		}
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			var buffer = SmallBufferCache.Acquire(4);
 			var count = await stream.ReadBlockAsync(buffer, 0, 4);
 			if (count < 4)

--- a/Manatee.Json/Parsing/NullParser.cs
+++ b/Manatee.Json/Parsing/NullParser.cs
@@ -64,16 +64,15 @@ namespace Manatee.Json.Parsing
 				return ("Unexpected end of input.", null);
 			}
 
-			var value = JsonValue.Null;
+			JsonValue value = null;
 			string errorMessage = null;
-			if (buffer[0] != 'n' && buffer[0] != 'N' &&
-			    buffer[1] != 'u' && buffer[1] != 'U' &&
-			    buffer[2] != 'l' && buffer[2] != 'L' &&
-			    buffer[3] != 'l' && buffer[3] != 'L')
-			{
-				value = null;
+			if ((buffer[0] == 'n' || buffer[0] == 'N') &&
+				(buffer[1] == 'u' || buffer[1] == 'U') &&
+				(buffer[2] == 'l' || buffer[2] == 'L') &&
+				(buffer[3] == 'l' || buffer[3] == 'L'))
+				value = JsonValue.Null;
+			else
 				errorMessage = $"Value not recognized: '{new string(buffer).Trim('\0')}'.";
-			}
 
 			SmallBufferCache.Release(buffer);
 			return (errorMessage, value);

--- a/Manatee.Json/Parsing/NullParser.cs
+++ b/Manatee.Json/Parsing/NullParser.cs
@@ -17,6 +17,9 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
+			if (source == null)
+				throw new ArgumentNullException(nameof(source));
+
 			value = null;
 
 			if (index + 4 > source.Length)
@@ -32,6 +35,9 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
+			if (stream == null)
+				throw new ArgumentNullException(nameof(stream));
+
 			value = null;
 
 			var buffer = SmallBufferCache.Acquire(4);
@@ -56,6 +62,9 @@ namespace Manatee.Json.Parsing
 		}
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
+			if (stream == null)
+				throw new ArgumentNullException(nameof(stream));
+
 			var buffer = SmallBufferCache.Acquire(4);
 			var count = await stream.ReadBlockAsync(buffer, 0, 4);
 			if (count < 4)

--- a/Manatee.Json/Parsing/NumberParser.cs
+++ b/Manatee.Json/Parsing/NumberParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,6 +18,13 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
+			if (source == null)
+				throw new ArgumentNullException(nameof(source));
+			if (index >= source.Length)
+				throw new ArgumentOutOfRangeException(nameof(index));
+
+			value = null;
+
 			var originalIndex = index;
 			while (index < source.Length)
 			{
@@ -27,7 +35,6 @@ namespace Manatee.Json.Parsing
 				if (!isNumber && allowExtraChars) break;
 				if (!isNumber)
 				{
-					value = null;
 					return "Expected ',', ']', or '}'.";
 				}
 
@@ -37,7 +44,6 @@ namespace Manatee.Json.Parsing
 			var result = source.Substring(originalIndex, index - originalIndex);
 			if (!double.TryParse(result, NumberStyles.Any, CultureInfo.InvariantCulture, out double dbl))
 			{
-				value = null;
 				return $"Value not recognized: '{result}'";
 			}
 
@@ -47,6 +53,9 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
+			if (stream == null)
+				throw new ArgumentNullException(nameof(stream));
+
 			var buffer = StringBuilderCache.Acquire();
 			var bufferIndex = 0;
 			while (stream.Peek() != -1)
@@ -80,6 +89,9 @@ namespace Manatee.Json.Parsing
 
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
+			if (stream == null)
+				throw new ArgumentNullException(nameof(stream));
+
 			var buffer = StringBuilderCache.Acquire();
 			var scratch = SmallBufferCache.Acquire(1);
 

--- a/Manatee.Json/Parsing/NumberParser.cs
+++ b/Manatee.Json/Parsing/NumberParser.cs
@@ -18,8 +18,6 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			if (source == null)
-				throw new ArgumentNullException(nameof(source));
 			if (index >= source.Length)
 				throw new ArgumentOutOfRangeException(nameof(index));
 
@@ -53,9 +51,6 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			var buffer = StringBuilderCache.Acquire();
 			var bufferIndex = 0;
 			while (stream.Peek() != -1)
@@ -89,9 +84,6 @@ namespace Manatee.Json.Parsing
 
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			var buffer = StringBuilderCache.Acquire();
 			var scratch = SmallBufferCache.Acquire(1);
 

--- a/Manatee.Json/Parsing/NumberParser.cs
+++ b/Manatee.Json/Parsing/NumberParser.cs
@@ -51,6 +51,8 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
+			value = null;
+
 			var buffer = StringBuilderCache.Acquire();
 			var bufferIndex = 0;
 			while (stream.Peek() != -1)
@@ -62,7 +64,6 @@ namespace Manatee.Json.Parsing
 
 				if (!_IsNumberChar(c))
 				{
-					value = null;
 					StringBuilderCache.Release(buffer);
 					return "Expected ',', ']', or '}'.";
 				}
@@ -74,7 +75,6 @@ namespace Manatee.Json.Parsing
 			var result = StringBuilderCache.GetStringAndRelease(buffer);
 			if (!double.TryParse(result, NumberStyles.Any, CultureInfo.InvariantCulture, out double dbl))
 			{
-				value = null;
 				return $"Value not recognized: '{result}'";
 			}
 

--- a/Manatee.Json/Parsing/ObjectParser.cs
+++ b/Manatee.Json/Parsing/ObjectParser.cs
@@ -14,10 +14,11 @@ namespace Manatee.Json.Parsing
 		}
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
+			value = null;
+
 			bool complete = false;
 
 			var obj = new JsonObject();
-			value = obj;
 			var length = source.Length;
 			index++;
 			while (index < length)
@@ -68,14 +69,16 @@ namespace Manatee.Json.Parsing
 			if (!complete)
 				return "Unterminated object (missing '}').";
 
+			value = obj;
 			return null;
 		}
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
+			value = null;
+
 			bool complete = false;
 
 			var obj = new JsonObject();
-			value = obj;
 			while (stream.Peek() != -1)
 			{
 				stream.Read(); // waste the '{' or ','
@@ -125,6 +128,7 @@ namespace Manatee.Json.Parsing
 			if (!complete)
 				return "Unterminated object (missing '}').";
 
+			value = obj;
 			return null;
 		}
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
@@ -132,7 +136,6 @@ namespace Manatee.Json.Parsing
 			bool complete = false;
 
 			var obj = new JsonObject();
-			JsonValue value = null;
 
 			var scratch = SmallBufferCache.Acquire(1);
 
@@ -209,10 +212,7 @@ namespace Manatee.Json.Parsing
 				errorMessage = "Unterminated object (missing '}').";
 			}
 
-			if (errorMessage == null)
-			{
-				value = obj;
-			}
+			JsonValue value = errorMessage == null ? obj : null;
 
 			SmallBufferCache.Release(scratch);
 			return (errorMessage, value);

--- a/Manatee.Json/Parsing/ObjectParser.cs
+++ b/Manatee.Json/Parsing/ObjectParser.cs
@@ -14,9 +14,6 @@ namespace Manatee.Json.Parsing
 		}
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			if (source == null)
-				throw new ArgumentNullException(nameof(source));
-
 			bool complete = false;
 
 			var obj = new JsonObject();
@@ -75,9 +72,6 @@ namespace Manatee.Json.Parsing
 		}
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			bool complete = false;
 
 			var obj = new JsonObject();
@@ -135,9 +129,6 @@ namespace Manatee.Json.Parsing
 		}
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			bool complete = false;
 
 			var obj = new JsonObject();

--- a/Manatee.Json/Parsing/StringParser.cs
+++ b/Manatee.Json/Parsing/StringParser.cs
@@ -17,6 +17,11 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
+			if (source == null)
+				throw new ArgumentNullException(nameof(source));
+
+			System.Diagnostics.Debug.Assert(index < source.Length && source[index] == '"');
+
 			value = null;
 
 			bool complete = false;
@@ -55,8 +60,12 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
+			if (stream == null)
+				throw new ArgumentNullException(nameof(stream));
+
 			value = null;
 
+			System.Diagnostics.Debug.Assert(stream.Peek() == '"');
 			stream.Read(); // waste the '"'
 
 			var builder = StringBuilderCache.Acquire();
@@ -64,8 +73,9 @@ namespace Manatee.Json.Parsing
 			var complete = false;
 			bool mustInterpret = false;
 			char c;
-			while ((c = (char)stream.Peek()) != -1)
+			while (stream.Peek() != -1)
 			{
+				c = (char)stream.Peek();
 				if (c == '\\')
 				{
 					mustInterpret = true;
@@ -100,17 +110,22 @@ namespace Manatee.Json.Parsing
 
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
+			if (stream == null)
+				throw new ArgumentNullException(nameof(stream));
+
 			var scratch = SmallBufferCache.Acquire(4);
 
 			await stream.TryRead(scratch, 0, 1, token); // waste the '"'
+			System.Diagnostics.Debug.Assert(scratch[0] == '"');
 
 			var builder = StringBuilderCache.Acquire();
 
 			var complete = false;
 			bool mustInterpret = false;
 			char c;
-			while ((c = (char)stream.Peek()) != -1)
+			while (stream.Peek() != -1)
 			{
+				c = (char)stream.Peek();
 				if (c == '\\')
 				{
 					mustInterpret = true;
@@ -195,13 +210,45 @@ namespace Manatee.Json.Parsing
 							break;
 						case 'u':
 							var length = 4;
-							var hex = int.Parse(source.Substring(index, 4), NumberStyles.HexNumber);
-							if (source.IndexOf("\\u", index + 4, 2) == index + 4)
+							if (index + length >= source.Length)
 							{
-								var hex2 = int.Parse(source.Substring(index + 6, 4), NumberStyles.HexNumber);
-								hex = (hex - 0xD800) * 0x400 + (hex2 - 0xDC00) % 0x400 + 0x10000;
-								length += 6;
+								errorMessage = $"Invalid escape sequence: '\\{c}{source.Substring(index)}'.";
+								break;
 							}
+
+							int hex;
+							if (!_IsValidHex(source, index, 4)
+							 || !int.TryParse(source.Substring(index, 4), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out hex))
+							{
+								errorMessage = $"Invalid escape sequence: '\\{c}{source.Substring(index, length)}'.";
+								break;
+							}
+
+							if (index + length + 2 < source.Length
+						     && source.IndexOf("\\u", index + length, 2) == index + length)
+							{
+								// +2 from \u
+								// +4 from the next four hex chars
+								length += 6;
+
+								if (index + length >= source.Length)
+								{
+									errorMessage = $"Invalid escape sequence: '\\{c}{source.Substring(index)}'.";
+									break;
+								}
+
+								if (!_IsValidHex(source, index + 6, 4)
+								 || !int.TryParse(source.Substring(index + 6, 4), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out int hex2))
+								{
+									errorMessage = $"Invalid escape sequence: '\\{c}{source.Substring(index, length)}'.";
+									break;
+								}
+								else
+								{
+									hex = (hex - 0xD800) * 0x400 + (hex2 - 0xDC00) % 0x400 + 0x10000;
+								}
+							}
+
 							append = char.ConvertFromUtf32(hex);
 							index += length;
 							break;
@@ -251,12 +298,18 @@ namespace Manatee.Json.Parsing
 			int? previousHex = null;
 
 			char c;
-			while ((c = (char)stream.Peek()) != -1)
+			while (stream.Peek() != -1)
 			{
-				stream.Read(); // eat this character
+				c = (char)stream.Read(); // eat this character
 
 				if (c == '\\')
 				{
+					if (stream.Peek() == -1)
+					{
+						StringBuilderCache.Release(builder);
+						return "Could not find end of string value.";
+					}
+
 					// escape sequence
 					var lookAhead = (char)stream.Peek();
 					if (!_MustInterpretComplex(lookAhead))
@@ -275,9 +328,19 @@ namespace Manatee.Json.Parsing
 
 						var buffer = SmallBufferCache.Acquire(4);
 						stream.Read(); // eat the 'u'
-						stream.Read(buffer, 0, 4);
-						var hexString = new string(buffer).Trim('\0');
-						var currentHex = int.Parse(hexString, NumberStyles.HexNumber);
+						if (4 != stream.Read(buffer, 0, 4))
+						{
+							StringBuilderCache.Release(builder);
+							return "Could not find end of string value.";
+						}
+
+						var hexString = new string(buffer, 0, 4);
+						if (!_IsValidHex(hexString, 0, 4)
+						 || !int.TryParse(hexString, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var currentHex))
+						{
+							StringBuilderCache.Release(builder);
+							return $"Invalid escape sequence: '\\{lookAhead}{hexString}'.";
+						}
 
 						if (previousHex != null)
 						{
@@ -324,6 +387,22 @@ namespace Manatee.Json.Parsing
 
 			value = StringBuilderCache.GetStringAndRelease(builder);
 			return errorMessage;
+		}
+
+		private static bool _IsValidHex(string source, int offset, int count)
+		{
+			for (int ii = offset; ii < offset + count; ++ii)
+			{
+				// if not a hex digit
+				if ((source[ii] < '0' || source[ii] > '9')
+				 && (source[ii] < 'A' || source[ii] > 'F')
+				 && (source[ii] < 'a' || source[ii] > 'f'))
+				{
+					return false;
+				}
+			}
+
+			return true;
 		}
 
 		/// <summary>
@@ -389,12 +468,20 @@ namespace Manatee.Json.Parsing
 			int? previousHex = null;
 
 			char c;
-			while ((c = (char)stream.Peek()) != -1)
+			while (stream.Peek() != -1)
 			{
 				await stream.TryRead(scratch, 0, 1); // eat this character
 
+				c = scratch[0];
 				if (c == '\\')
 				{
+					if (stream.Peek() == -1)
+					{
+						StringBuilderCache.Release(builder);
+						SmallBufferCache.Release(scratch);
+						return ("Could not find end of string value.", null);
+					}
+
 					// escape sequence
 					var lookAhead = (char)stream.Peek();
 					if (!_MustInterpretComplex(lookAhead))

--- a/Manatee.Json/Parsing/StringParser.cs
+++ b/Manatee.Json/Parsing/StringParser.cs
@@ -17,9 +17,6 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(string source, ref int index, out JsonValue value, bool allowExtraChars)
 		{
-			if (source == null)
-				throw new ArgumentNullException(nameof(source));
-
 			System.Diagnostics.Debug.Assert(index < source.Length && source[index] == '"');
 
 			value = null;
@@ -60,9 +57,6 @@ namespace Manatee.Json.Parsing
 
 		public string TryParse(TextReader stream, out JsonValue value)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			value = null;
 
 			System.Diagnostics.Debug.Assert(stream.Peek() == '"');
@@ -110,9 +104,6 @@ namespace Manatee.Json.Parsing
 
 		public async Task<(string errorMessage, JsonValue value)> TryParseAsync(TextReader stream, CancellationToken token)
 		{
-			if (stream == null)
-				throw new ArgumentNullException(nameof(stream));
-
 			var scratch = SmallBufferCache.Acquire(4);
 
 			await stream.TryRead(scratch, 0, 1, token); // waste the '"'


### PR DESCRIPTION
- Check lengths before substring
- Check hex chars before TryParse'ing
- int.TryParse instead of int.Parse
- Fix cast bug for EOF check on streams

Remaining exception during Pex runs: \uXXXX\uYYYY with an invalid UTF-32 codepoint, try...catch?