### PR TITLE
Improve JsonPath performance

### DIFF
--- a/Manatee.Json.Tests/Path/ParsingTest.cs
+++ b/Manatee.Json.Tests/Path/ParsingTest.cs
@@ -260,5 +260,35 @@ namespace Manatee.Json.Tests.Path
 		{
 			Run(JsonPathWith.Search(""), "$..''");
 		}
+		[Test]
+		public void UnaryNegate_WithAdd()
+		{
+			Run(JsonPathWith.Array(jv => jv.Length() + -3 > 1), "$[?(@.length + -3 > 1)]");
+		}
+		[Test]
+		public void UnaryNegate_WithSubtract()
+		{
+			Run(JsonPathWith.Array(jv => jv.Length() - -3 > 1), "$[?(@.length - -3 > 1)]");
+		}
+		[Test]
+		public void UnaryNegate_WithMultiply()
+		{
+			Run(JsonPathWith.Array(jv => jv.Length() * -3 > 1), "$[?(@.length * -3 > 1)]");
+		}
+		[Test]
+		public void UnaryNegate_WithDivide()
+		{
+			Run(JsonPathWith.Array(jv => jv.Length() / -3 > 1), "$[?(@.length / -3 > 1)]");
+		}
+		[Test]
+		public void UnaryNegate_WithModulo()
+		{
+			Run(JsonPathWith.Array(jv => jv.Length() % -3 > 1), "$[?(@.length % -3 > 1)]");
+		}
+		[Test]
+		public void Complicated_SubtractNegate()
+		{
+			Run(JsonPathWith.Array(jv => (jv.Length() - -3) - -5 > 1), "$[?((@.length - -3)--5 > 1)]");
+		}
 	}
 }

--- a/Manatee.Json.Tests/Path/ToStringTest.cs
+++ b/Manatee.Json.Tests/Path/ToStringTest.cs
@@ -183,22 +183,22 @@ namespace Manatee.Json.Tests.Path
 		[Test]
 		public void ArrayFilterExpression_SubtractionGreaterThanValue()
 		{
-			Run("$[?(@.length-1 > 2)]", JsonPathWith.Array(jv => jv.Length() - 1 > 2));
+			Run("$[?((@.length-1) > 2)]", JsonPathWith.Array(jv => jv.Length() - 1 > 2));
 		}
 		[Test]
 		public void ArrayFilterExpression_MultiplicationGreaterThanEqualValue()
 		{
-			Run("$[?(@.length*1 >= 2)]", JsonPathWith.Array(jv => jv.Length() * 1 >= 2));
+			Run("$[?((@.length*1) >= 2)]", JsonPathWith.Array(jv => jv.Length() * 1 >= 2));
 		}
 		[Test]
 		public void ArrayFilterExpression_DivisionEqualValue()
 		{
-			Run("$[?(@.length/1 == 2)]", JsonPathWith.Array(jv => jv.Length() / 1 == 2));
+			Run("$[?((@.length/1) == 2)]", JsonPathWith.Array(jv => jv.Length() / 1 == 2));
 		}
 		[Test]
 		public void ArrayFilterExpression_ModulusEqualValue()
 		{
-			Run("$[?(@.length%1 == 2)]", JsonPathWith.Array(jv => jv.Length() % 1 == 2));
+			Run("$[?((@.length%1) == 2)]", JsonPathWith.Array(jv => jv.Length() % 1 == 2));
 		}
 		[Test]
 		public void ArrayIndexExpression_IndexOfNumber()

--- a/Manatee.Json/Path/ArrayParameters/SliceQuery.cs
+++ b/Manatee.Json/Path/ArrayParameters/SliceQuery.cs
@@ -15,7 +15,14 @@ namespace Manatee.Json.Path.ArrayParameters
 		}
 		public IEnumerable<JsonValue> Find(JsonArray json, JsonValue root)
 		{
-			return Slices.SelectMany(s => s.Find(json, root)).Distinct();
+			var results = new HashSet<JsonValue>();
+
+			foreach (var slice in Slices)
+			{
+				results.UnionWith(slice.Find(json, root));
+			}
+
+			return results;
 		}
 		public override string ToString()
 		{

--- a/Manatee.Json/Path/Expressions/AddExpression.cs
+++ b/Manatee.Json/Path/Expressions/AddExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class AddExpression<T> : ExpressionTreeBranch<T>, IEquatable<AddExpression<T>>
 	{
-		protected override int BasePriority => 2;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -21,7 +19,8 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			return $"{Left}+{Right}";
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{Left}+{right}";
 		}
 		public bool Equals(AddExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/AndExpression.cs
+++ b/Manatee.Json/Path/Expressions/AndExpression.cs
@@ -4,15 +4,15 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class AndExpression<T> : ExpressionTreeBranch<T>, IEquatable<AndExpression<T>>
 	{
-		protected override int BasePriority => 0;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			return (bool)Left.Evaluate(json, root) && (bool)Right.Evaluate(json, root);
 		}
 		public override string ToString()
 		{
-			return $"{Left} && {Right}";
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{left} && {right}";
 		}
 		public bool Equals(AndExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/ArrayIndexExpression.cs
+++ b/Manatee.Json/Path/Expressions/ArrayIndexExpression.cs
@@ -9,8 +9,6 @@ namespace Manatee.Json.Path.Expressions
 		public int Index { get; set; }
 		public ExpressionTreeNode<T> IndexExpression { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var value = IsLocal ? json.AsJsonValue() : root;

--- a/Manatee.Json/Path/Expressions/ConversionExpression.cs
+++ b/Manatee.Json/Path/Expressions/ConversionExpression.cs
@@ -8,8 +8,6 @@ namespace Manatee.Json.Path.Expressions
 		public ExpressionTreeNode<T> Root { get; set; }
 		public Type TargetType { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var value = Root.Evaluate(json, root);

--- a/Manatee.Json/Path/Expressions/DivideExpression.cs
+++ b/Manatee.Json/Path/Expressions/DivideExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class DivideExpression<T> : ExpressionTreeBranch<T>, IEquatable<DivideExpression<T>>
 	{
-		protected override int BasePriority => 3;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -15,8 +13,8 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			var left = Left.Priority <= Priority ? $"({Left})" : Left.ToString();
-			var right = Right.Priority <= Priority ? $"({Right})" : Right.ToString();
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
 			return $"{left}/{right}";
 		}
 		public bool Equals(DivideExpression<T> other)

--- a/Manatee.Json/Path/Expressions/ExponentExpression.cs
+++ b/Manatee.Json/Path/Expressions/ExponentExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class ExponentExpression<T> : ExpressionTreeBranch<T>, IEquatable<ExponentExpression<T>>
 	{
-		protected override int BasePriority => 4;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Convert.ToDouble(Left.Evaluate(json, root));
@@ -14,8 +12,8 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			var left = Left.Priority <= Priority ? $"({Left})" : Left.ToString();
-			var right = Right.Priority <= Priority ? $"({Right})" : Right.ToString();
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
 			return $"{left}^{right}";
 		}
 		public bool Equals(ExponentExpression<T> other)

--- a/Manatee.Json/Path/Expressions/ExpressionTreeNode.cs
+++ b/Manatee.Json/Path/Expressions/ExpressionTreeNode.cs
@@ -2,17 +2,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal abstract class ExpressionTreeNode<T>
 	{
-		private int _priorityBump;
-
-		public int Priority => BasePriority + _priorityBump;
-
-		protected abstract int BasePriority { get; }
-
 		public abstract object Evaluate(T json, JsonValue root);
-
-		public void BumpPriority()
-		{
-			_priorityBump += 10;
-		}
 	}
 }

--- a/Manatee.Json/Path/Expressions/FieldExpression.cs
+++ b/Manatee.Json/Path/Expressions/FieldExpression.cs
@@ -8,8 +8,6 @@ namespace Manatee.Json.Path.Expressions
 		public FieldInfo Field { get; set; }
 		public object Source { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			if (Field.FieldType == typeof(string) ||

--- a/Manatee.Json/Path/Expressions/HasPropertyExpression.cs
+++ b/Manatee.Json/Path/Expressions/HasPropertyExpression.cs
@@ -6,8 +6,6 @@ namespace Manatee.Json.Path.Expressions
 	{
 		public string Name { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var value = json as JsonValue;

--- a/Manatee.Json/Path/Expressions/IndexOfExpression.cs
+++ b/Manatee.Json/Path/Expressions/IndexOfExpression.cs
@@ -9,8 +9,6 @@ namespace Manatee.Json.Path.Expressions
 		public JsonValue Parameter { get; set; }
 		public ExpressionTreeNode<JsonArray> ParameterExpression { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var value = IsLocal ? json.AsJsonValue() : root;

--- a/Manatee.Json/Path/Expressions/IsEqualExpression.cs
+++ b/Manatee.Json/Path/Expressions/IsEqualExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class IsEqualExpression<T> : ExpressionTreeBranch<T>, IEquatable<IsEqualExpression<T>>
 	{
-		protected override int BasePriority => 1;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -16,7 +14,9 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			return $"{Left} == {Right}";
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{left} == {right}";
 		}
 		public bool Equals(IsEqualExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/IsGreaterThanEqualExpression.cs
+++ b/Manatee.Json/Path/Expressions/IsGreaterThanEqualExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class IsGreaterThanEqualExpression<T> : ExpressionTreeBranch<T>, IEquatable<IsGreaterThanEqualExpression<T>>
 	{
-		protected override int BasePriority => 1;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -14,7 +12,9 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			return $"{Left} >= {Right}";
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{left} >= {right}";
 		}
 		public bool Equals(IsGreaterThanEqualExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/IsGreaterThanExpression.cs
+++ b/Manatee.Json/Path/Expressions/IsGreaterThanExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class IsGreaterThanExpression<T> : ExpressionTreeBranch<T>, IEquatable<IsGreaterThanExpression<T>>
 	{
-		protected override int BasePriority => 1;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -14,7 +12,9 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			return $"{Left} > {Right}";
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{left} > {right}";
 		}
 		public bool Equals(IsGreaterThanExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/IsLessThanEqualExpression.cs
+++ b/Manatee.Json/Path/Expressions/IsLessThanEqualExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class IsLessThanEqualExpression<T> : ExpressionTreeBranch<T>, IEquatable<IsLessThanEqualExpression<T>>
 	{
-		protected override int BasePriority => 1;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -14,7 +12,9 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			return $"{Left} <= {Right}";
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{left} <= {right}";
 		}
 		public bool Equals(IsLessThanEqualExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/IsLessThanExpression.cs
+++ b/Manatee.Json/Path/Expressions/IsLessThanExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class IsLessThanExpression<T> : ExpressionTreeBranch<T>, IEquatable<IsLessThanExpression<T>>
 	{
-		protected override int BasePriority => 1;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -14,7 +12,9 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			return $"{Left} < {Right}";
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{left} < {right}";
 		}
 		public bool Equals(IsLessThanExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/IsNotEqualExpression.cs
+++ b/Manatee.Json/Path/Expressions/IsNotEqualExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class IsNotEqualExpression<T> : ExpressionTreeBranch<T>, IEquatable<IsNotEqualExpression<T>>
 	{
-		protected override int BasePriority => 1;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -16,7 +14,9 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			return $"{Left} != {Right}";
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{left} != {right}";
 		}
 		public bool Equals(IsNotEqualExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/LengthExpression.cs
+++ b/Manatee.Json/Path/Expressions/LengthExpression.cs
@@ -5,8 +5,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class LengthExpression<T> : PathExpression<T>, IEquatable<LengthExpression<T>>
 	{
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			JsonArray array;

--- a/Manatee.Json/Path/Expressions/ModuloExpression.cs
+++ b/Manatee.Json/Path/Expressions/ModuloExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class ModuloExpression<T> : ExpressionTreeBranch<T>, IEquatable<ModuloExpression<T>>
 	{
-		protected override int BasePriority => 2;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -15,8 +13,8 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			var left = Left.Priority <= Priority ? $"({Left})" : Left.ToString();
-			var right = Right.Priority <= Priority ? $"({Right})" : Right.ToString();
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
 			return $"{left}%{right}";
 		}
 		public bool Equals(ModuloExpression<T> other)

--- a/Manatee.Json/Path/Expressions/MultiplyExpression.cs
+++ b/Manatee.Json/Path/Expressions/MultiplyExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class MultiplyExpression<T> : ExpressionTreeBranch<T>, IEquatable<MultiplyExpression<T>>
 	{
-		protected override int BasePriority => 3;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -15,8 +13,8 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			var left = Left.Priority <= Priority ? $"({Left})" : Left.ToString();
-			var right = Right.Priority <= Priority ? $"({Right})" : Right.ToString();
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
 			return $"{left}*{right}";
 		}
 		public bool Equals(MultiplyExpression<T> other)

--- a/Manatee.Json/Path/Expressions/NameExpresssion.cs
+++ b/Manatee.Json/Path/Expressions/NameExpresssion.cs
@@ -9,8 +9,6 @@ namespace Manatee.Json.Path.Expressions
 		public string Name { get; set; }
 		public ExpressionTreeNode<T> NameExp { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var value = IsLocal ? json.AsJsonValue() : root;

--- a/Manatee.Json/Path/Expressions/NegateExpression.cs
+++ b/Manatee.Json/Path/Expressions/NegateExpression.cs
@@ -6,15 +6,13 @@ namespace Manatee.Json.Path.Expressions
 	{
 		public ExpressionTreeNode<T> Root { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			return -Convert.ToDouble(Root.Evaluate(json, root));
 		}
 		public override string ToString()
 		{
-			return Root is AddExpression<T> || Root is SubtractExpression<T>
+			return Root is ExpressionTreeBranch<T>
 					   ? $"-({Root})"
 				       : $"-{Root}";
 		}

--- a/Manatee.Json/Path/Expressions/NotExpression.cs
+++ b/Manatee.Json/Path/Expressions/NotExpression.cs
@@ -6,8 +6,6 @@ namespace Manatee.Json.Path.Expressions
 	{
 		public ExpressionTreeNode<T> Root { get; set; }
 
-		protected override int BasePriority => 5;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var result = Root.Evaluate(json, root);
@@ -15,10 +13,7 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			return Root is AndExpression<T> || Root is OrExpression<T> ||
-				   Root is IsEqualExpression<T> || Root is IsNotEqualExpression<T> ||
-				   Root is IsLessThanExpression<T> || Root is IsLessThanEqualExpression<T> ||
-				   Root is IsGreaterThanExpression<T> || Root is IsGreaterThanEqualExpression<T>
+			return Root is ExpressionTreeBranch<T>
 					   ? $"!({Root})"
 				       : $"!{Root}";
 		}

--- a/Manatee.Json/Path/Expressions/OrExpression.cs
+++ b/Manatee.Json/Path/Expressions/OrExpression.cs
@@ -4,14 +4,14 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class OrExpression<T> : ExpressionTreeBranch<T>, IEquatable<OrExpression<T>>
 	{
-		protected override int BasePriority => 0;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			return (bool)Left.Evaluate(json, root) || (bool)Right.Evaluate(json, root);
 		}
 		public override string ToString()
 		{
+			var left = Left is ExpressionTreeBranch<T> ? $"({Left})" : Left.ToString();
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
 			return $"{Left} || {Right}";
 		}
 		public bool Equals(OrExpression<T> other)

--- a/Manatee.Json/Path/Expressions/Parsing/AddExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/AddExpressionParser.cs
@@ -2,9 +2,9 @@
 {
 	internal class AddExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("+");
+			return input[index] == '+';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/AddExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/AddExpressionParser.cs
@@ -6,10 +6,10 @@
 		{
 			return input[index] == '+';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new AddExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Add };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/AndExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/AndExpressionParser.cs
@@ -2,9 +2,13 @@
 {
 	internal class AndExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("&&");
+			if (index + 1 >= input.Length)
+				return false;
+
+			return input[index] == '&'
+				&& input[index + 1] == '&';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/AndExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/AndExpressionParser.cs
@@ -10,10 +10,10 @@
 			return input[index] == '&'
 				&& input[index + 1] == '&';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index += 2;
-			node = new AndExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.And };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/ConstantBooleanExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ConstantBooleanExpressionParser.cs
@@ -17,23 +17,25 @@
 
 			return false;
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
-			var substring = source.Substring(index);
-			if (substring.StartsWith("true"))
+			expression = null;
+			if (source[index] == 't')
 			{
 				index += 4;
-				node = new ValueExpression<T> {Value = true};
-				return null;
+				expression = new ValueExpression { Value = true };
 			}
-			if (substring.StartsWith("false"))
+			else if (source[index] == 'f')
 			{
 				index += 5;
-				node = new ValueExpression<T> {Value = false};
-				return null;
+				expression = new ValueExpression { Value = false };
 			}
-			node = null;
-			return "Boolean value not recognized.";
+			else
+			{
+				return "Boolean value not recoginized.";
+			}
+
+			return null;
 		}
 	}
 }

--- a/Manatee.Json/Path/Expressions/Parsing/ConstantBooleanExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ConstantBooleanExpressionParser.cs
@@ -2,9 +2,20 @@
 {
 	internal class ConstantBooleanExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("true") || input.StartsWith("false");
+			if (input[index] == 't'
+				&& index + 3 < input.Length)
+			{
+				return input.IndexOf("true", index, 4) == index;
+			}
+			else if (input[index] == 'f'
+				&& index + 4 < input.Length)
+			{
+				return input.IndexOf("false", index, 5) == index;
+			}
+
+			return false;
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/ConstantNumberExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ConstantNumberExpressionParser.cs
@@ -8,17 +8,18 @@ namespace Manatee.Json.Path.Expressions.Parsing
 		{
 			return char.IsDigit(input[index]);
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
+			expression = null;
+
 			double? number;
 			var error = source.GetNumber(ref index, out number);
 			if (error != null)
 			{
-				node = null;
 				return error;
 			}
 
-			node = new ValueExpression<T> {Value = number};
+			expression = new ValueExpression { Value = number };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/ConstantNumberExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ConstantNumberExpressionParser.cs
@@ -4,9 +4,9 @@ namespace Manatee.Json.Path.Expressions.Parsing
 {
 	internal class ConstantNumberExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return char.IsDigit(input[0]);
+			return char.IsDigit(input[index]);
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/ConstantStringExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ConstantStringExpressionParser.cs
@@ -9,16 +9,18 @@ namespace Manatee.Json.Path.Expressions.Parsing
 		{
 			return input[index] == '"' || input[index] == '\'';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
+			expression = null;
+
 			string value;
 			var error = source.GetKey(ref index, out value);
 			if (error != null)
 			{
-				node = null;
 				return error;
 			}
-			node = new ValueExpression<T> {Value = value};
+			
+			expression = new ValueExpression { Value = value };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/ConstantStringExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ConstantStringExpressionParser.cs
@@ -5,9 +5,9 @@ namespace Manatee.Json.Path.Expressions.Parsing
 {
 	internal class ConstantStringExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input[0].In('"', '\'');
+			return input[index] == '"' || input[index] == '\'';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/DivideExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/DivideExpressionParser.cs
@@ -2,9 +2,9 @@
 {
 	internal class DivideExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("/");
+			return input[index] == '/';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/DivideExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/DivideExpressionParser.cs
@@ -6,10 +6,10 @@
 		{
 			return input[index] == '/';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new DivideExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Divide };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/ExponentExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ExponentExpressionParser.cs
@@ -2,9 +2,9 @@
 {
 	internal class ExponentExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("^");
+			return input[index] == '^';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/ExponentExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ExponentExpressionParser.cs
@@ -6,10 +6,10 @@
 		{
 			return input[index] == '^';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new ExponentExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Exponent };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/ExpressionEndParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ExpressionEndParser.cs
@@ -2,9 +2,9 @@
 {
 	internal class ExpressionEndParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input[0] == ')';
+			return input[index] == ')';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/ExpressionEndParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ExpressionEndParser.cs
@@ -4,12 +4,18 @@
 	{
 		public bool Handles(string input, int index)
 		{
-			return input[index] == ')';
+			return input[index] == ')' || input[index] == ']';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
-			index++;
-			node = null;
+			if (source[index] == ']')
+			{
+				expression = null;
+				return null;
+			}
+
+			index += 1;
+			expression = new OperatorExpression { Operator = JsonPathOperator.GroupEnd };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/GroupExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/GroupExpressionParser.cs
@@ -2,9 +2,9 @@
 {
 	internal class GroupExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input[0] == '(';
+			return input[index] == '(';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/GroupExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/GroupExpressionParser.cs
@@ -6,12 +6,11 @@
 		{
 			return input[index] == '(';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
-			index++;
-			var error = JsonPathExpressionParser.Parse(source, ref index, out node);
-			node?.BumpPriority();
-			return error;
+			index += 1;
+			expression = new OperatorExpression { Operator = JsonPathOperator.GroupStart };
+			return null;
 		}
 	}
 }

--- a/Manatee.Json/Path/Expressions/Parsing/IJsonPathExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IJsonPathExpressionParser.cs
@@ -2,7 +2,8 @@
 {
 	internal interface IJsonPathExpressionParser
 	{
-		bool Handles(string input);
+		bool Handles(string input, int index);
+
 		string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node);
 	}
 }

--- a/Manatee.Json/Path/Expressions/Parsing/IJsonPathExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IJsonPathExpressionParser.cs
@@ -4,6 +4,6 @@
 	{
 		bool Handles(string input, int index);
 
-		string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node);
+		string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression);
 	}
 }

--- a/Manatee.Json/Path/Expressions/Parsing/IsEqualExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsEqualExpressionParser.cs
@@ -8,10 +8,10 @@
 				&& input[index] == '='
 				&& input[index + 1] == '=';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index += 2;
-			node = new IsEqualExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Equal };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/IsEqualExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsEqualExpressionParser.cs
@@ -2,9 +2,11 @@
 {
 	internal class IsEqualExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("==");
+			return index + 1 < input.Length
+				&& input[index] == '='
+				&& input[index + 1] == '=';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/IsGreaterThanEqualExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsGreaterThanEqualExpressionParser.cs
@@ -2,9 +2,11 @@
 {
 	internal class IsGreaterThanEqualExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith(">=");
+			return index + 1 < input.Length
+				&& input[index] == '>'
+				&& input[index + 1] == '=';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/IsGreaterThanEqualExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsGreaterThanEqualExpressionParser.cs
@@ -8,10 +8,10 @@
 				&& input[index] == '>'
 				&& input[index + 1] == '=';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index += 2;
-			node = new IsGreaterThanEqualExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.GreaterThanOrEqual };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/IsGreaterThanExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsGreaterThanExpressionParser.cs
@@ -2,9 +2,13 @@
 {
 	internal class IsGreaterThanExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith(">") && !input.StartsWith(">=");
+			if (input[index] != '>')
+				return false;
+
+			return index + 1 >= input.Length
+				|| input[index + 1] != '=';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/IsGreaterThanExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsGreaterThanExpressionParser.cs
@@ -10,10 +10,10 @@
 			return index + 1 >= input.Length
 				|| input[index + 1] != '=';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new IsGreaterThanExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.GreaterThan };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/IsLessThanEqualExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsLessThanEqualExpressionParser.cs
@@ -8,10 +8,10 @@
 				&& input[index] == '<'
 				&& input[index + 1] == '=';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index += 2;
-			node = new IsLessThanEqualExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.LessThanOrEqual };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/IsLessThanEqualExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsLessThanEqualExpressionParser.cs
@@ -2,9 +2,11 @@
 {
 	internal class IsLessThanEqualExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("<=");
+			return index + 1 < input.Length
+				&& input[index] == '<'
+				&& input[index + 1] == '=';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/IsLessThanExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsLessThanExpressionParser.cs
@@ -2,9 +2,13 @@
 {
 	internal class IsLessThanExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("<") && !input.StartsWith("<=");
+			if (input[index] != '<')
+				return false;
+
+			return index + 1 >= input.Length
+				|| input[index + 1] != '=';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/IsLessThanExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsLessThanExpressionParser.cs
@@ -10,10 +10,10 @@
 			return index + 1 >= input.Length
 				|| input[index + 1] != '=';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new IsLessThanExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.LessThan };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/IsNotEqualExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsNotEqualExpressionParser.cs
@@ -8,10 +8,10 @@
 				&& input[index] == '!'
 				&& input[index + 1] == '=';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index += 2;
-			node = new IsNotEqualExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.NotEqual };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/IsNotEqualExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/IsNotEqualExpressionParser.cs
@@ -2,9 +2,11 @@
 {
 	internal class IsNotEqualExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("!=");
+			return index + 1 < input.Length
+				&& input[index] == '!'
+				&& input[index + 1] == '=';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/JsonPathExpression.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/JsonPathExpression.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+
+namespace Manatee.Json.Path.Expressions.Parsing
+{
+	internal abstract class JsonPathExpression
+	{
+	}
+
+	internal class ValueExpression : JsonPathExpression
+	{
+		public object Value { get; set; }
+	}
+
+	internal class PathValueExpression<T> : ValueExpression
+	{
+		public PathExpression<T> Path
+		{
+			get { return (PathExpression<T>)base.Value; }
+			set { base.Value = value; }
+		}
+	}
+
+	internal class OperatorExpression : JsonPathExpression
+	{
+		public JsonPathOperator Operator { get; set; }
+
+		public bool IsBinary
+		{
+			get
+			{
+				switch (Operator)
+				{
+					case JsonPathOperator.Add:
+					case JsonPathOperator.And:
+					case JsonPathOperator.Divide:
+					case JsonPathOperator.Exponent:
+					case JsonPathOperator.Equal:
+					case JsonPathOperator.GreaterThan:
+					case JsonPathOperator.GreaterThanOrEqual:
+					case JsonPathOperator.LessThan:
+					case JsonPathOperator.LessThanOrEqual:
+					case JsonPathOperator.NotEqual:
+					case JsonPathOperator.Modulo:
+					case JsonPathOperator.Multiply:
+					case JsonPathOperator.Subtract:
+					case JsonPathOperator.Or:
+						return true;
+					default:
+						return false;
+				}
+			}
+		}
+
+		public List<JsonPathExpression> Children { get; } = new List<JsonPathExpression>();
+	}
+}

--- a/Manatee.Json/Path/Expressions/Parsing/JsonPathExpressionContext.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/JsonPathExpressionContext.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Manatee.Json.Path.Expressions.Parsing
+{
+	/// <summary>
+	/// Provides context for the Shunting-yard Algorithm implementation.
+	/// </summary>
+    internal class JsonPathExpressionContext
+    {
+		/// <summary>
+		/// Output expression stack.
+		/// </summary>
+		public Stack<JsonPathExpression> Output { get; } = new Stack<JsonPathExpression>();
+
+		/// <summary>
+		/// Operator expression stack.
+		/// </summary>
+		public Stack<OperatorExpression> Operators { get; } = new Stack<OperatorExpression>();
+
+		/// <summary>
+		/// The last encountered expression.
+		/// </summary>
+		/// <remarks>
+		/// Used to differentiate unary negation from subtraction.
+		/// </remarks>
+		public JsonPathExpression LastExpression { get; set; }
+
+		public string CreateExpressionTreeNode<TIn>(out ExpressionTreeNode<TIn> root)
+		{
+			root = null;
+			if (Output.Count != 1)
+				return "No expression to parse.";
+			if (Operators.Count > 0)
+				return "Unbalanced expression.";
+
+			root = _MakeHasPropertyIfNameExpression(_Visit<TIn>(Output.Pop(), null));
+			return null;
+		}
+		private ExpressionTreeNode<TIn> _Visit<TIn>(JsonPathExpression expr, OperatorExpression parentExpr)
+		{
+			if (expr is null)
+				return null;
+
+			if (expr is PathValueExpression<TIn> path)
+			{
+				return path.Path;
+			}
+			if (expr is ValueExpression value)
+			{
+				return new ValueExpression<TIn> { Value = value.Value };
+			}
+			else if (expr is OperatorExpression op)
+			{
+				var left = _Visit<TIn>(op.Children[0], op);
+				var right = _Visit<TIn>(op.Children.Count > 1 ? op.Children[1] : null, op);
+
+				_CheckAndReplaceIfHasPropertyNeeded(op.Operator, ref left, ref right);
+				switch (op.Operator)
+				{
+					case JsonPathOperator.Add:
+						return new AddExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.And:
+						return new AndExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.Divide:
+						return new DivideExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.Exponent:
+						return new ExponentExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.Equal:
+						return new IsEqualExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.GreaterThan:
+						return new IsGreaterThanExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.GreaterThanOrEqual:
+						return new IsGreaterThanEqualExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.LessThan:
+						return new IsLessThanExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.LessThanOrEqual:
+						return new IsLessThanEqualExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.NotEqual:
+						return new IsNotEqualExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.Modulo:
+						return new ModuloExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.Multiply:
+						return new MultiplyExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.Subtract:
+						return new SubtractExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.Or:
+						return new OrExpression<TIn> { Left = left, Right = right, };
+					case JsonPathOperator.Negate:
+						return _VisitNegate(left);
+					case JsonPathOperator.Not:
+						return new NotExpression<TIn> { Root = _MakeHasPropertyIfNameExpression(left) };
+					default:
+						break;
+				}
+			}
+
+			throw new NotSupportedException($"Expressions of type {expr.GetType()} are not supported");
+		}
+		/// <summary>
+		/// Constant terms are negated immediately.
+		/// </summary>
+		private ExpressionTreeNode<TIn> _VisitNegate<TIn>(ExpressionTreeNode<TIn> left)
+		{
+			// Always apply Negate to path values
+			if (left is PathValueExpression<TIn>)
+				return new NegateExpression<TIn> { Root = left };
+
+			if (left is ValueExpression<TIn> value && value.Value != null)
+			{
+				// Fold.
+				var negatedValue = _Negate(value.Value);
+				if (negatedValue != null)
+				{
+					return new ValueExpression<TIn> { Value = negatedValue };
+				}
+			}
+
+			// Always apply Negate to anything other than a negatable value
+			return new NegateExpression<TIn> { Root = left };
+		}
+		private object _Negate(object value)
+		{
+			if (value is byte @byte) return -@byte;
+			if (value is sbyte @sbyte) return -@sbyte;
+			if (value is short @short) return -@short;
+			if (value is ushort @ushort) return -@ushort;
+			if (value is int @int) return -@int;
+			if (value is uint @uint) return -@uint;
+			if (value is long @long) return -@long;
+			if (value is ulong) return null; // can't negate a ulong
+			if (value is float @float) return -@float;
+			if (value is double @double) return -@double;
+			if (value is decimal @decimal) return -@decimal;
+			return null;
+		}
+		/// <summary>
+		/// Converts <paramref name="left"/> and <paramref name="right"/> to <see cref="HasPropertyExpression{T}"/>
+		/// nodes if either are <see cref="NameExpression{T}"/> nodes being used in boolean contexts. Otherwise,
+		/// it leaves the nodes as-is.
+		/// </summary>
+		/// <typeparam name="TIn">Type of the resulting JSON expression.</typeparam>
+		/// <param name="op">Operator applied to <paramref name="left"/> and <paramref name="right"/>.</param>
+		/// <param name="left">Left hand side of <paramref name="op"/>.</param>
+		/// <param name="right">Right hand side of <paramref name="op"/>.</param>
+		private void _CheckAndReplaceIfHasPropertyNeeded<TIn>(JsonPathOperator op, ref ExpressionTreeNode<TIn> left, ref ExpressionTreeNode<TIn> right)
+		{
+			if (left is NameExpression<TIn> || right is NameExpression<TIn>)
+			{
+				var namedLeft = left as NameExpression<TIn>;
+				var namedRight = right as NameExpression<TIn>;
+				switch (op)
+				{
+					case JsonPathOperator.And:
+					case JsonPathOperator.Or:
+					case JsonPathOperator.Not:
+						// Explicit boolean context, convert one or both sides
+						// as necessary.
+						left = _MakeHasPropertyIfNameExpression(left);
+						right = _MakeHasPropertyIfNameExpression(right);
+						break;
+
+					case JsonPathOperator.Equal:
+					case JsonPathOperator.NotEqual:
+						// Convert only if one side is a named expression and the other
+						// is a boolean expression tree, but not if both are named 
+						// expressions.
+						// 
+						// Why? If we've got == or != with two named expressions
+						// we're comparing their values and should not convert both
+						// to HasPropertyExpression's.
+						if (namedLeft == null ^ namedRight == null)
+						{
+							var isBoolean = namedLeft == null
+										  ? _IsBooleanResult(left) 
+										  : _IsBooleanResult(right);
+							if (isBoolean)
+							{
+								// We've evaluated that the context of our Equal/NotEqual
+								// operands is boolean. Convert whichever side is a 
+								// named expression to a HasProperty expression.
+								left = _MakeHasPropertyIfNameExpression(left);
+								right = _MakeHasPropertyIfNameExpression(right);
+							}
+						}
+						break;
+
+					default:
+						// All other operators (relational too) imply a value comparison rather
+						// than a comparison against HasProperty.
+						break;
+				}
+			}
+		}
+		private static ExpressionTreeNode<TIn> _MakeHasPropertyIfNameExpression<TIn>(ExpressionTreeNode<TIn> node)
+		{
+			if (node is NameExpression<TIn> named)
+			{
+				return new HasPropertyExpression<TIn>
+				{
+					Path = named.Path,
+					IsLocal = named.IsLocal,
+					Name = named.Name
+				};
+			}
+
+			return node;
+		}
+		private bool _IsBooleanResult<TIn>(ExpressionTreeNode<TIn> node)
+		{
+			if (node == null)
+				return false;
+
+			// Boolean values are a boolean result.
+			if (node is ValueExpression<TIn> value && value.Value != null && (value.Value is bool || value.Value is bool?))
+				return true;
+
+			// NotExpressions are always a boolean result.
+			if (node is NotExpression<TIn>)
+				return true;
+
+			if (node is ExpressionTreeBranch<TIn> branch)
+			{
+				// Any subexpression returning a boolean 
+				// value is obviously a boolean result.
+				return branch is AndExpression<TIn>
+					|| branch is OrExpression<TIn>
+					|| branch is IsEqualExpression<TIn>
+					|| branch is IsNotEqualExpression<TIn>
+					|| branch is IsGreaterThanEqualExpression<TIn>
+					|| branch is IsGreaterThanExpression<TIn>
+					|| branch is IsLessThanEqualExpression<TIn>
+					|| branch is IsLessThanExpression<TIn>;
+			}
+
+			// All other expressions do not have boolean results.
+			return false;
+		}
+	}
+}

--- a/Manatee.Json/Path/Expressions/Parsing/JsonPathExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/JsonPathExpressionParser.cs
@@ -22,6 +22,7 @@ namespace Manatee.Json.Path.Expressions.Parsing
 		public static string Parse<T, TIn>(string source, ref int index, out Expression<T, TIn> expr)
 		{
 			var error = Parse(source, ref index, out ExpressionTreeNode<TIn> root);
+
 			if (error != null)
 			{
 				expr = null;
@@ -36,15 +37,15 @@ namespace Manatee.Json.Path.Expressions.Parsing
 			expr = new Expression<T, TIn>(root);
 			return null;
 		}
+		
 		public static string Parse<TIn>(string source, ref int index, out ExpressionTreeNode<TIn> root)
 		{
-			var nodes = new List<ExpressionTreeNode<TIn>>();
-			var length = source.Length;
-			ExpressionTreeNode<TIn> node;
 			root = null;
-			do
+
+			var context = new JsonPathExpressionContext();
+			while (index < source.Length)
 			{
-				var errorMessage = source.SkipWhiteSpace(ref index, length, out char c);
+				var errorMessage = source.SkipWhiteSpace(ref index, source.Length, out _);
 				if (errorMessage != null) return errorMessage;
 
 				IJsonPathExpressionParser foundParser = null;
@@ -58,52 +59,190 @@ namespace Manatee.Json.Path.Expressions.Parsing
 				}
 
 				if (foundParser == null) return "Unrecognized JSON Path Expression element.";
-				errorMessage = foundParser.TryParse(source, ref index, out node);
+				errorMessage = foundParser.TryParse<TIn>(source, ref index, out var expression);
 				if (errorMessage != null) return errorMessage;
-				if (node != null)
-					nodes.Add(node);
-			} while (index < length && node != null);
+				if (expression == null)
+					break;
 
-			root = nodes.Count == 1
-				       ? _CheckNode(nodes[0], null)
-				       : _BuildTree(nodes);
-			return null;
-		}
-
-		private static ExpressionTreeNode<T> _BuildTree<T>(List<ExpressionTreeNode<T>> nodes)
-		{
-			if (!nodes.Any()) return null;
-			var minPriority = nodes.Min(n => n.Priority);
-			var root = nodes.Last(n => n.Priority == minPriority);
-			if (root is ExpressionTreeBranch<T> branch && branch.Right == null && branch.Left == null)
-			{
-				var split = nodes.LastIndexOf(root);
-				var left = nodes.Take(split).ToList();
-				var right = nodes.Skip(split + 1).ToList();
-				branch.Left = _CheckNode(_BuildTree(left), branch);
-				branch.Right = _CheckNode(_BuildTree(right), branch);
-			}
-			if (root is NotExpression<T> not)
-			{
-				var split = nodes.IndexOf(root);
-				var right = nodes.Skip(split + 1).FirstOrDefault();
-				not.Root = _CheckNode(right, null);
-			}
-			return root;
-		}
-
-		private static ExpressionTreeNode<T> _CheckNode<T>(ExpressionTreeNode<T> node, ExpressionTreeBranch<T> root)
-		{
-			if (node is NameExpression<T> named && (root == null || root.Priority == 0))
-			{
-				return new HasPropertyExpression<T>
+				//
+				// Implements the Shunting-yard Algorithm
+				//
+				if (expression is ValueExpression value)
 				{
-					Path = named.Path,
-					IsLocal = named.IsLocal,
-					Name = named.Name
-				};
+					// Values go immediately onto the output stack
+					context.Output.Push(value);
+				}
+				else if (expression is OperatorExpression op)
+				{
+					if (op.Operator == JsonPathOperator.GroupStart)
+					{
+						// Push open parenthesis onto the operator stack
+						context.Operators.Push(new OperatorExpression { Operator = JsonPathOperator.GroupStart });
+					}
+					else if (op.Operator == JsonPathOperator.GroupEnd)
+					{
+						// Resolve all operators from the closing parenthesis
+						// back to the matching open parenthesis.
+
+						// While:
+						//   1. We have operators
+						//   2. and, they are not the open parentheses...
+						while (context.Operators.Count > 0
+							&& context.Operators.Peek().Operator != JsonPathOperator.GroupStart)
+						{
+							// Get the operator...
+							var expr = context.Operators.Pop();
+
+							// ...pop its children from the stack...
+							_GetRequiredChildrenFromOutput(context, expr);
+
+							// ...and push the completed operator sub-tree onto the output stack
+							context.Output.Push(expr);
+						}
+
+						if (context.Operators.Count == 0
+							|| context.Operators.Pop().Operator != JsonPathOperator.GroupStart)
+							return "Unbalanced parentheses.";
+					}
+					else
+					{
+						if (op.Operator == JsonPathOperator.Subtract)
+						{
+							// Check if we need to switch this to a negation operator
+							if (context.LastExpression is OperatorExpression lastOp
+								&& lastOp.Operator != JsonPathOperator.GroupEnd)
+							{
+								// ...if the prior expression is an operator,
+								// but not the end of a grouping expression
+								// then this subtraction is actually a negation
+								// of the next term.
+								op.Operator = JsonPathOperator.Negate;
+							}
+						}
+
+						// For all other operators, resolve any operators
+						// of greater (or equal right-assoc) precedence 
+						// before pushing ourselves onto the operator stack
+
+						while (context.Operators.Count > 0)
+						{
+							var top = context.Operators.Peek();
+
+							// While:
+							//   1. There is an op with greater precedence
+							//   2. or, the operator has equal and is left-assoc
+							//   3. and, it is not group start...
+							var precedence = _Compare(op, top);
+							if ((precedence < 0
+								|| (precedence == 0 && !_IsRightAssociative(top.Operator)))
+								&& top.Operator != JsonPathOperator.GroupStart)
+							{
+								// Get the operator...
+								var expr = context.Operators.Pop();
+
+								// ...pop its children from the stack...
+								_GetRequiredChildrenFromOutput(context, expr);
+
+								// ...and push the completed operator sub-tree onto the output stack
+								context.Output.Push(expr);
+							}
+							else
+							{
+								break;
+							}
+						}
+
+						context.Operators.Push(op);
+					}
+				}
+
+				context.LastExpression = expression;
 			}
-			return node;
+
+			// Convert the expression into an ExpressionTreeNode
+			return context.CreateExpressionTreeNode(out root);
+		}
+
+		private static void _GetRequiredChildrenFromOutput(JsonPathExpressionContext context, OperatorExpression expr)
+		{
+			if (expr.IsBinary)
+			{
+				var second = context.Output.Pop();
+				var first = context.Output.Pop();
+				expr.Children.Add(first);
+				expr.Children.Add(second);
+			}
+			else
+			{
+				// unary
+				expr.Children.Add(context.Output.Pop());
+			}
+		}
+
+		private static int _Compare(OperatorExpression a, OperatorExpression b)
+		{
+			return _Precedence(a.Operator).CompareTo(_Precedence(b.Operator));
+		}
+
+		private static int _Precedence(JsonPathOperator op)
+		{
+			// Based on JavaScript's operator precedence
+			switch (op)
+			{
+				case JsonPathOperator.GroupStart:
+				case JsonPathOperator.GroupEnd:
+					return 20;
+
+				case JsonPathOperator.Negate:
+				case JsonPathOperator.Not:
+					return 16;
+
+				case JsonPathOperator.Exponent:
+					return 15;
+
+				case JsonPathOperator.Multiply:
+				case JsonPathOperator.Divide:
+				case JsonPathOperator.Modulo:
+					return 14;
+
+				case JsonPathOperator.Add:
+				case JsonPathOperator.Subtract:
+					return 13;
+
+				case JsonPathOperator.GreaterThan:
+				case JsonPathOperator.GreaterThanOrEqual:
+				case JsonPathOperator.LessThan:
+				case JsonPathOperator.LessThanOrEqual:
+					return 11;
+
+				case JsonPathOperator.Equal:
+				case JsonPathOperator.NotEqual:
+					return 10;
+
+				case JsonPathOperator.And:
+					return 6;
+
+				case JsonPathOperator.Or:
+					return 5;
+
+				default:
+					return 0;
+			}
+		}
+
+		private static bool _IsRightAssociative(JsonPathOperator op)
+		{
+			// Based on JavaScript's operator associativity
+			switch (op)
+			{
+				case JsonPathOperator.Negate:
+				case JsonPathOperator.Not:
+				case JsonPathOperator.Exponent:
+					return true;
+					
+				default:
+					return false;
+			}
 		}
 	}
 }

--- a/Manatee.Json/Path/Expressions/Parsing/JsonPathExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/JsonPathExpressionParser.cs
@@ -46,10 +46,19 @@ namespace Manatee.Json.Path.Expressions.Parsing
 			{
 				var errorMessage = source.SkipWhiteSpace(ref index, length, out char c);
 				if (errorMessage != null) return errorMessage;
-				var substring = source.Substring(index);
-				var parser = Parsers.FirstOrDefault(p => p.Handles(substring));
-				if (parser == null) return "Unrecognized JSON Path Expression element.";
-				errorMessage = parser.TryParse(source, ref index, out node);
+
+				IJsonPathExpressionParser foundParser = null;
+				foreach (var parser in Parsers)
+				{
+					if (parser.Handles(source, index))
+					{
+						foundParser = parser;
+						break;
+					}
+				}
+
+				if (foundParser == null) return "Unrecognized JSON Path Expression element.";
+				errorMessage = foundParser.TryParse(source, ref index, out node);
 				if (errorMessage != null) return errorMessage;
 				if (node != null)
 					nodes.Add(node);

--- a/Manatee.Json/Path/Expressions/Parsing/JsonPathOperator.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/JsonPathOperator.cs
@@ -1,0 +1,25 @@
+﻿namespace Manatee.Json.Path.Expressions.Parsing
+{
+	internal enum JsonPathOperator
+	{
+		Add,
+		And,
+		Constant,
+		Divide,
+		Exponent,
+		Equal,
+		GreaterThan,
+		GreaterThanOrEqual,
+		GroupStart,
+		GroupEnd,
+		LessThan,
+		LessThanOrEqual,
+		NotEqual,
+		Modulo,
+		Multiply,
+		Negate,
+		Not,
+		Or,
+		Subtract,
+	}
+}

--- a/Manatee.Json/Path/Expressions/Parsing/ModuloExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ModuloExpressionParser.cs
@@ -6,10 +6,10 @@
 		{
 			return input[index] == '%';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new ModuloExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Modulo };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/ModuloExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/ModuloExpressionParser.cs
@@ -2,9 +2,9 @@
 {
 	internal class ModuloExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("%");
+			return input[index] == '%';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/MultiplyExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/MultiplyExpressionParser.cs
@@ -2,9 +2,9 @@
 {
 	internal class MultiplyExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("*");
+			return input[index] == '*';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/MultiplyExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/MultiplyExpressionParser.cs
@@ -6,10 +6,10 @@
 		{
 			return input[index] == '*';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new MultiplyExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Multiply };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/NotExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/NotExpressionParser.cs
@@ -2,9 +2,13 @@
 {
 	internal class NotExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("!") && !input.StartsWith("!=");
+			if (input[index] != '!')
+				return false;
+
+			return index + 1 >= input.Length
+				|| input[index + 1] != '=';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/NotExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/NotExpressionParser.cs
@@ -10,10 +10,10 @@
 			return index + 1 >= input.Length
 				|| input[index + 1] != '=';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new NotExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Not };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/OrExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/OrExpressionParser.cs
@@ -2,9 +2,11 @@
 {
 	internal class OrExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("||");
+			return index + 1 < input.Length
+				&& input[index] == '|'
+				&& input[index + 1] == '|';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/OrExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/OrExpressionParser.cs
@@ -8,10 +8,10 @@
 				&& input[index] == '|'
 				&& input[index + 1] == '|';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index += 2;
-			node = new OrExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Or };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/PathExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/PathExpressionParser.cs
@@ -10,9 +10,9 @@ namespace Manatee.Json.Path.Expressions.Parsing
 {
 	internal class PathExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input[0].In('@', '$');
+			return input[index] == '@' || input[index] == '$';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/Parsing/PathExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/PathExpressionParser.cs
@@ -14,29 +14,28 @@ namespace Manatee.Json.Path.Expressions.Parsing
 		{
 			return input[index] == '@' || input[index] == '$';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<T>(string source, ref int index, out JsonPathExpression expression)
 		{
+			expression = null;
+			PathExpression<T> node;
+
 			var isLocal = source[index] == '@';
 			var error = JsonPathParser.Parse(source, ref index, out JsonPath path);
 			// Swallow this error from the path parser and assume the path just ended.
 			// If it's really a syntax error, the expression parser should catch it.
 			if (error != null && error != "Unrecognized JSON Path element.")
 			{
-				node = null;
 				return error;
 			}
 
-			var name = path.Operators.Last() as NameOperator;
-			var length = path.Operators.Last() as LengthOperator;
-			var array = path.Operators.Last() as ArrayOperator;
-			if (name != null)
+			var lastOp = path.Operators.Last();
+			if (lastOp is NameOperator name)
 			{
 				path.Operators.Remove(name);
 				if (name.Name == "indexOf")
 				{
 					if (source[index] != '(')
 					{
-						node = null;
 						return "Expected '('.  'indexOf' operator requires a parameter.";
 					}
 					index++;
@@ -45,59 +44,57 @@ namespace Manatee.Json.Path.Expressions.Parsing
 					// If it's really a syntax error, the expression parser should catch it.
 					if (error != null && error != "Expected \',\', \']\', or \'}\'.")
 					{
-						node = null;
 						return $"Error parsing parameter for 'indexOf' expression: {error}.";
 					}
 					if (source[index] != ')')
 					{
-						node = null;
 						return "Expected ')'.";
 					}
 					index++;
 					node = new IndexOfExpression<T>
-						{
-							Path = path,
-							IsLocal = isLocal,
-							Parameter = parameter
-						};
+					{
+						Path = path,
+						IsLocal = isLocal,
+						Parameter = parameter
+					};
 				}
 				else
 					node = new NameExpression<T>
-						{
-							Path = path,
-							IsLocal = isLocal,
-							Name = name.Name
-						};
+					{
+						Path = path,
+						IsLocal = isLocal,
+						Name = name.Name
+					};
 			}
-			else if (length != null)
+			else if (lastOp is LengthOperator length)
 			{
 				path.Operators.Remove(length);
 				node = new LengthExpression<T>
-					{
-						Path = path,
-						IsLocal = isLocal
-					};
+				{
+					Path = path,
+					IsLocal = isLocal
+				};
 			}
-			else if (array != null)
+			else if (lastOp is ArrayOperator array)
 			{
 				path.Operators.Remove(array);
 				var query = array.Query as SliceQuery;
 				var constant = query?.Slices.FirstOrDefault()?.Index;
 				if (query == null || query.Slices.Count() != 1 || !constant.HasValue)
 				{
-					node = null;
 					return "JSON Path expression indexers only support single constant values.";
 				}
 				node = new ArrayIndexExpression<T>
-					{
-						Path = path,
-						IsLocal = isLocal,
-						Index = constant.Value
-					};
+				{
+					Path = path,
+					IsLocal = isLocal,
+					Index = constant.Value
+				};
 			}
 			else
 				throw new NotImplementedException();
 
+			expression = new PathValueExpression<T> { Path = node };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/SubtractExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/SubtractExpressionParser.cs
@@ -4,13 +4,13 @@
 	{
 		public bool Handles(string input, int index)
 		{
-			// TODO: Determine how to identify negations separately from subtractions.
+			// Negation is handled during the Shunting-yard Algorithm loop
 			return input[index] == '-';
 		}
-		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
+		public string TryParse<TIn>(string source, ref int index, out JsonPathExpression expression)
 		{
 			index++;
-			node = new SubtractExpression<T>();
+			expression = new OperatorExpression { Operator = JsonPathOperator.Subtract };
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Expressions/Parsing/SubtractExpressionParser.cs
+++ b/Manatee.Json/Path/Expressions/Parsing/SubtractExpressionParser.cs
@@ -2,10 +2,10 @@
 {
 	internal class SubtractExpressionParser : IJsonPathExpressionParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
 			// TODO: Determine how to identify negations separately from subtractions.
-			return input.StartsWith("-");
+			return input[index] == '-';
 		}
 		public string TryParse<T>(string source, ref int index, out ExpressionTreeNode<T> node)
 		{

--- a/Manatee.Json/Path/Expressions/PathExpression.cs
+++ b/Manatee.Json/Path/Expressions/PathExpression.cs
@@ -8,8 +8,6 @@ namespace Manatee.Json.Path.Expressions
 		public JsonPath Path { get; set; }
 		public bool IsLocal { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var value = IsLocal ? json as JsonValue : root;

--- a/Manatee.Json/Path/Expressions/SubtractExpression.cs
+++ b/Manatee.Json/Path/Expressions/SubtractExpression.cs
@@ -4,8 +4,6 @@ namespace Manatee.Json.Path.Expressions
 {
 	internal class SubtractExpression<T> : ExpressionTreeBranch<T>, IEquatable<SubtractExpression<T>>
 	{
-		protected override int BasePriority => 2;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			var left = Left.Evaluate(json, root);
@@ -15,9 +13,8 @@ namespace Manatee.Json.Path.Expressions
 		}
 		public override string ToString()
 		{
-			if (Right?.Priority == Priority)
-				return $"{Left}-({Right})";
-			return $"{Left}-{Right}";
+			var right = Right is ExpressionTreeBranch<T> ? $"({Right})" : Right.ToString();
+			return $"{Left}-{right}";
 		}
 		public bool Equals(SubtractExpression<T> other)
 		{

--- a/Manatee.Json/Path/Expressions/ValueExpression.cs
+++ b/Manatee.Json/Path/Expressions/ValueExpression.cs
@@ -6,8 +6,6 @@ namespace Manatee.Json.Path.Expressions
 	{
 		public object Value { get; set; }
 
-		protected override int BasePriority => 6;
-
 		public override object Evaluate(T json, JsonValue root)
 		{
 			return Value;

--- a/Manatee.Json/Path/JsonPath.cs
+++ b/Manatee.Json/Path/JsonPath.cs
@@ -32,9 +32,12 @@ namespace Manatee.Json.Path
 		/// <returns></returns>
 		public JsonArray Evaluate(JsonValue json)
 		{
-			var current = new JsonArray {json};
-			var found = Operators.Aggregate(current, (c, o) => o.Evaluate(c, json));
-			return found;
+			var current = new JsonArray { json };
+			foreach (var op in Operators)
+			{
+				current = op.Evaluate(current, json);
+			}
+			return current;
 		}
 		/// <summary>
 		/// Returns a string that represents the current object.

--- a/Manatee.Json/Path/Operators/ArrayOperator.cs
+++ b/Manatee.Json/Path/Operators/ArrayOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Manatee.Json.Internal;
 
@@ -15,14 +16,28 @@ namespace Manatee.Json.Path.Operators
 
 		public JsonArray Evaluate(JsonArray json, JsonValue root)
 		{
-			return new JsonArray(json.SelectMany(v => v.Type == JsonValueType.Array
-				                                          ? Query.Find(v.Array, root)
-				                                          : v.Type == JsonValueType.Object
-					                                          ? Query.Find(v.Object.Values.ToJson(), root)
-					                                          : Enumerable.Empty<JsonValue>())
-			                         .WhereNotNull());
-		}
+			var results = new List<JsonValue>();
 
+			foreach (var value in json)
+			{
+				_Evaluate(value, root, results);
+			}
+
+			return new JsonArray(results);
+		}
+		private void _Evaluate(JsonValue value, JsonValue root, List<JsonValue> results)
+		{
+			switch (value.Type)
+			{
+				case JsonValueType.Array:
+					results.AddRange(Query.Find(value.Array, root));
+					break;
+
+				case JsonValueType.Object:
+					results.AddRange(Query.Find(new JsonArray(value.Object.Values), root));
+					break;
+			}
+		}
 		public override string ToString()
 		{
 			return $"[{Query}]";

--- a/Manatee.Json/Path/Operators/IndexOfOperator.cs
+++ b/Manatee.Json/Path/Operators/IndexOfOperator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Manatee.Json.Path.Expressions;
 
@@ -15,10 +16,17 @@ namespace Manatee.Json.Path.Operators
 
 		public JsonArray Evaluate(JsonArray json, JsonValue root)
 		{
+			var results = new JsonArray();
 			var parameter = Parameter.Evaluate(json, root);
-			return json.Where(v => v.Type == JsonValueType.Array)
-			           .Select(v => (JsonValue) v.Array.IndexOf(parameter))
-			           .ToJson();
+			foreach (var value in json)
+			{
+				if (value.Type == JsonValueType.Array)
+				{
+					results.Add(value.Array.IndexOf(parameter));
+				}
+			}
+
+			return results;
 		}
 		public override string ToString()
 		{

--- a/Manatee.Json/Path/Operators/LengthOperator.cs
+++ b/Manatee.Json/Path/Operators/LengthOperator.cs
@@ -9,9 +9,15 @@ namespace Manatee.Json.Path.Operators
 
 		public JsonArray Evaluate(JsonArray json, JsonValue root)
 		{
-			return json.Where(v => v.Type == JsonValueType.Array)
-			           .Select(v => (JsonValue) v.Array.Count)
-			           .ToJson();
+			var results = new JsonArray();
+			foreach (var value in json)
+			{
+				if (value.Type == JsonValueType.Array)
+				{
+					results.Add(value.Array.Count);
+				}
+			}
+			return results;
 		}
 		public override string ToString()
 		{

--- a/Manatee.Json/Path/Operators/NameOperator.cs
+++ b/Manatee.Json/Path/Operators/NameOperator.cs
@@ -15,9 +15,16 @@ namespace Manatee.Json.Path.Operators
 
 		public JsonArray Evaluate(JsonArray json, JsonValue root)
 		{
-			return new JsonArray(json.Select(v => v.Type == JsonValueType.Object && v.Object.ContainsKey(Name)
-				                                      ? v.Object[Name]
-				                                      : null).WhereNotNull());
+			var results = new JsonArray();
+			foreach (var value in json)
+			{
+				if (value.Type == JsonValueType.Object
+					&& value.Object.TryGetValue(Name, out var match))
+				{
+					results.Add(match);
+				}
+			}
+			return results;
 		}
 		public override string ToString()
 		{

--- a/Manatee.Json/Path/Operators/WildCardOperator.cs
+++ b/Manatee.Json/Path/Operators/WildCardOperator.cs
@@ -16,18 +16,24 @@ namespace Manatee.Json.Path.Operators
 
 		public JsonArray Evaluate(JsonArray json, JsonValue root)
 		{
-			return new JsonArray(json.SelectMany(v =>
-				{
-					switch (v.Type)
-					{
-						case JsonValueType.Object:
-							return v.Object.Values;
-						case JsonValueType.Array:
-							return v.Array;
-						default:
-							return Enumerable.Empty<JsonValue>();
-					}
-				}).WhereNotNull());
+			var results = new JsonArray();
+			foreach (var value in json)
+			{
+				_Evaluate(value, results);
+			}
+			return results;
+		}
+		private void _Evaluate(JsonValue value, JsonArray results)
+		{
+			switch(value.Type)
+			{
+				case JsonValueType.Object:
+					results.AddRange(value.Object.Values);
+					break;
+				case JsonValueType.Array:
+					results.AddRange(value.Array);
+					break;
+			}
 		}
 		public override string ToString()
 		{

--- a/Manatee.Json/Path/Parsing/ExpressionFilterParser.cs
+++ b/Manatee.Json/Path/Parsing/ExpressionFilterParser.cs
@@ -18,7 +18,7 @@ namespace Manatee.Json.Path.Parsing
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{
-			index += 3;
+			index += 2;
 			Expression<bool, JsonValue> expression;
 			var error = JsonPathExpressionParser.Parse(source, ref index, out expression);
 

--- a/Manatee.Json/Path/Parsing/ExpressionFilterParser.cs
+++ b/Manatee.Json/Path/Parsing/ExpressionFilterParser.cs
@@ -7,9 +7,14 @@ namespace Manatee.Json.Path.Parsing
 {
 	internal class ExpressionFilterParser : IJsonPathParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("[?(");
+			if (index + 2 >= input.Length)
+				return false;
+
+			return input[index] == '['
+				&& input[index + 1] == '?'
+				&& input[index + 2] == '(';
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{

--- a/Manatee.Json/Path/Parsing/ExpressionIndexParser.cs
+++ b/Manatee.Json/Path/Parsing/ExpressionIndexParser.cs
@@ -7,9 +7,13 @@ namespace Manatee.Json.Path.Parsing
 {
 	internal class ExpressionIndexParser : IJsonPathParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("[(");
+			if (index + 1 >= input.Length)
+				return false;
+
+			return input[index] == '['
+				&& input[index + 1] == '(';
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{

--- a/Manatee.Json/Path/Parsing/ExpressionIndexParser.cs
+++ b/Manatee.Json/Path/Parsing/ExpressionIndexParser.cs
@@ -17,7 +17,7 @@ namespace Manatee.Json.Path.Parsing
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{
-			index += 2;
+			index += 1;
 			Expression<int, JsonArray> expression;
 			var error = JsonPathExpressionParser.Parse(source, ref index, out expression);
 

--- a/Manatee.Json/Path/Parsing/IJsonPathParser.cs
+++ b/Manatee.Json/Path/Parsing/IJsonPathParser.cs
@@ -2,7 +2,7 @@
 {
 	internal interface IJsonPathParser
 	{
-		bool Handles(string input);
+		bool Handles(string input, int index);
 
 		string TryParse(string source, ref int index, ref JsonPath path);
 	}

--- a/Manatee.Json/Path/Parsing/IndexedArrayParser.cs
+++ b/Manatee.Json/Path/Parsing/IndexedArrayParser.cs
@@ -6,10 +6,16 @@ namespace Manatee.Json.Path.Parsing
 {
 	internal class IndexedArrayParser : IJsonPathParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.Length > 1 && input[0] == '[' && (char.IsDigit(input[1]) || input[1].In('-', ':'));
+			if (index + 1 >= input.Length)
+				return false;
+
+			return input[index] == '['
+				&& (char.IsDigit(input[index + 1])
+					|| (input[index + 1] == '-' || input[index + 1] == ':'));
 		}
+
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{
 			if (path == null) return "Start token not found.";

--- a/Manatee.Json/Path/Parsing/JsonPathParser.cs
+++ b/Manatee.Json/Path/Parsing/JsonPathParser.cs
@@ -35,12 +35,26 @@ namespace Manatee.Json.Path.Parsing
 			{
 				var errorMessage = source.SkipWhiteSpace(ref index, length, out char c);
 				if (errorMessage != null) return errorMessage;
+
 				var substring = source.Substring(index);
-				var parser = Parsers.FirstOrDefault(p => p.Handles(substring));
-				if (parser == null) return "Unrecognized JSON Path element.";
-				errorMessage = parser.TryParse(source, ref index, ref path);
+
+				IJsonPathParser foundParser = null;
+				foreach (var parser in Parsers)
+				{
+					if (parser.Handles(source, index))
+					{
+						foundParser = parser;
+						break;
+					}
+				}
+
+				if (foundParser == null)
+					return "Unrecognized JSON Path element.";
+
+				errorMessage = foundParser.TryParse(source, ref index, ref path);
 				if (errorMessage != null) return errorMessage;
 			}
+
 			return null;
 		}
 	}

--- a/Manatee.Json/Path/Parsing/PathObjectParser.cs
+++ b/Manatee.Json/Path/Parsing/PathObjectParser.cs
@@ -4,9 +4,16 @@ namespace Manatee.Json.Path.Parsing
 {
 	internal class PathObjectParser : IJsonPathParser
 	{
-		public bool Handles(string input)
+		private static readonly string allowedChars = "_'\"*";
+
+		public bool Handles(string input, int index)
 		{
-			return input.Length >= 2 && input[0] == '.' && (char.IsLetterOrDigit(input[1]) || input[1].In('_', '\'', '"', '*'));
+			if (index + 1 >= input.Length)
+				return false;
+
+			return input[index] == '.'
+				&& (char.IsLetterOrDigit(input[index + 1])
+					|| allowedChars.IndexOf(input[index + 1]) >= 0);
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{

--- a/Manatee.Json/Path/Parsing/SearchIndexedArrayParser.cs
+++ b/Manatee.Json/Path/Parsing/SearchIndexedArrayParser.cs
@@ -6,9 +6,16 @@ namespace Manatee.Json.Path.Parsing
 {
 	internal class SearchIndexedArrayParser : IJsonPathParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.Length > 4 && input.StartsWith("..[") && (char.IsDigit(input[3]) || input[3].In('-', ':'));
+			if (index + 3 >= input.Length)
+				return false;
+
+			return input[index] == '.'
+				&& input[index + 1] == '.'
+				&& input[index + 2] == '['
+				&& (char.IsDigit(input[index + 3])
+					|| (input[index + 3] == '-' || input[index + 3] == ':'));
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{

--- a/Manatee.Json/Path/Parsing/SearchParser.cs
+++ b/Manatee.Json/Path/Parsing/SearchParser.cs
@@ -4,9 +4,17 @@ namespace Manatee.Json.Path.Parsing
 {
 	internal class SearchParser : IJsonPathParser
 	{
-		public bool Handles(string input)
+		private static readonly string allowedChars = "_'\"*";
+
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("..") && input.Length >= 3 && (char.IsLetterOrDigit(input[2]) || input[2].In('_', '\'', '"', '*'));
+			if (index + 2 >= input.Length)
+				return false;
+
+			return input[index] == '.'
+				&& input[index + 1] == '.'
+				&& (char.IsLetterOrDigit(input[index + 2])
+					|| allowedChars.IndexOf(input[index + 2]) >= 0);
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{

--- a/Manatee.Json/Path/Parsing/StartParser.cs
+++ b/Manatee.Json/Path/Parsing/StartParser.cs
@@ -2,9 +2,9 @@
 {
 	internal class StartParser : IJsonPathParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input[0] == '$' || input[0] == '@';
+			return input[index] == '$' || input[index] == '@';
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{

--- a/Manatee.Json/Path/Parsing/WildcardArrayParser.cs
+++ b/Manatee.Json/Path/Parsing/WildcardArrayParser.cs
@@ -2,9 +2,14 @@
 {
 	internal class WildcardArrayParser : IJsonPathParser
 	{
-		public bool Handles(string input)
+		public bool Handles(string input, int index)
 		{
-			return input.StartsWith("[*]");
+			if (index + 2 >= input.Length)
+				return false;
+
+			return input[index] == '['
+				&& input[index + 1] == '*'
+				&& input[index + 2] == ']';
 		}
 		public string TryParse(string source, ref int index, ref JsonPath path)
 		{

--- a/Manatee.Json/Path/SearchParameters/LengthSearchParameter.cs
+++ b/Manatee.Json/Path/SearchParameters/LengthSearchParameter.cs
@@ -10,20 +10,37 @@ namespace Manatee.Json.Path.SearchParameters
 
 		public IEnumerable<JsonValue> Find(IEnumerable<JsonValue> json, JsonValue root)
 		{
-			return new JsonArray(json.SelectMany(v =>
-				{
-					var contents = new List<JsonValue> {v.Array.Count};
-					switch (v.Type)
+			var results = new JsonArray();
+
+			foreach (var value in json)
+			{
+				_Find(value, root, results);
+			}
+
+			return results;
+		}
+		private void _Find(JsonValue value, JsonValue root, JsonArray results)
+		{
+			if (value.Type == JsonValueType.Array)
+				results.Add(value.Array.Count);
+			else
+				results.Add(1);
+
+			switch (value.Type)
+			{
+				case JsonValueType.Object:
+					foreach (var subValue in value.Object.Values)
 					{
-						case JsonValueType.Object:
-							contents.AddRange(v.Object.Values.SelectMany(jv => Find(new JsonArray {jv}, root)));
-							break;
-						case JsonValueType.Array:
-							contents.AddRange(v.Array.SelectMany(jv => Find(new JsonArray {jv}, root)));
-							break;
+						_Find(subValue, root, results);
 					}
-					return contents;
-				}));
+					break;
+				case JsonValueType.Array:
+					foreach (var subValue in value.Array)
+					{
+						_Find(subValue, root, results);
+					}
+					break;
+			}
 		}
 		public override string ToString()
 		{

--- a/Manatee.Json/Path/SearchParameters/NameSearchParameter.cs
+++ b/Manatee.Json/Path/SearchParameters/NameSearchParameter.cs
@@ -16,22 +16,36 @@ namespace Manatee.Json.Path.SearchParameters
 
 		public IEnumerable<JsonValue> Find(IEnumerable<JsonValue> json, JsonValue root)
 		{
-			return new JsonArray(json.SelectMany(v =>
+			var results = new JsonArray();
+
+			foreach (var value in json)
 			{
-				switch (v.Type)
-				{
-					case JsonValueType.Object:
-						var match = v.Object.ContainsKey(_name) ? v.Object[_name] : null;
-						var search = v.Object.Values.SelectMany(jv => Find(new[] {jv}, root)).ToList();
-						if (match != null)
-							search.Insert(0, match);
-						return search;
-					case JsonValueType.Array:
-						return new JsonArray(v.Array.SelectMany(jv => Find(new[] {jv}, root)));
-					default:
-						return Enumerable.Empty<JsonValue>();
-				}
-			}));
+				_Find(value, root, results);
+			}
+
+			return results;
+		}
+		private void _Find(JsonValue value, JsonValue root, JsonArray results)
+		{
+			switch (value.Type)
+			{
+				case JsonValueType.Object:
+					if (value.Object.TryGetValue(_name, out var match))
+						results.Add(match);
+					foreach (var subValue in value.Object.Values)
+					{
+						_Find(subValue, root, results);
+					}
+					break;
+				case JsonValueType.Array:
+					foreach (var subValue in value.Array)
+					{
+						_Find(subValue, root, results);
+					}
+					break;
+				default:
+					break;
+			}
 		}
 		public override string ToString()
 		{

--- a/Manatee.Json/Path/SearchParameters/WildCardSearchParameter.cs
+++ b/Manatee.Json/Path/SearchParameters/WildCardSearchParameter.cs
@@ -10,20 +10,31 @@ namespace Manatee.Json.Path.SearchParameters
 
 		public IEnumerable<JsonValue> Find(IEnumerable<JsonValue> json, JsonValue root)
 		{
-			return new JsonArray(json.SelectMany(v =>
-				{
-					var contents = new List<JsonValue> {v};
-					switch (v.Type)
+			var results = new JsonArray();
+			foreach (var value in json)
+			{
+				_Find(value, root, results);
+			}
+			return results;
+		}
+		private void _Find(JsonValue value, JsonValue root, JsonArray results)
+		{
+			results.Add(value);
+			switch (value.Type)
+			{
+				case JsonValueType.Object:
+					foreach (var subValue in value.Object.Values)
 					{
-						case JsonValueType.Object:
-							contents.AddRange(v.Object.Values.SelectMany(jv => Find(new JsonArray {jv}, root)));
-							break;
-						case JsonValueType.Array:
-							contents.AddRange(v.Array.SelectMany(jv => Find(new JsonArray {jv}, root)));
-							break;
+						_Find(subValue, root, results);
 					}
-					return contents;
-				}));
+					break;
+				case JsonValueType.Array:
+					foreach (var subValue in value.Array)
+					{
+						_Find(subValue, root, results);
+					}
+					break;
+			}
 		}
 		public override string ToString()
 		{

--- a/Manatee.Json/Path/Slice.cs
+++ b/Manatee.Json/Path/Slice.cs
@@ -103,6 +103,24 @@ namespace Manatee.Json.Path
 			var end = _ResolveIndex(_end ?? json.Count, json.Count);
 			var step = Math.Max(_step ?? 1, 1);
 
+			// quick copy
+			if (start == 0 && end == json.Count && step == 1)
+				return new List<JsonValue>(json);
+
+			if (step == 1)
+			{
+				var result = new JsonValue[end - start];
+				json.CopyTo(start, result, 0, end - start);
+				return result;
+			}
+			else
+			{
+				return _FindSlow(json, start, end, step);
+			}
+		}
+
+		private static IEnumerable<JsonValue> _FindSlow(JsonArray json, int start, int end, int step)
+		{
 			var index = start;
 			var list = new List<JsonValue>();
 			while (index < end)


### PR DESCRIPTION
We're now evaluating JSON Path in our product. These commits begin work on improving the performance in path parsing and some of the basic queries (I've not started on expressions just yet). This follows the same general strategies in my other commits:

- Reduce allocations
- Reduce string allocations
- Remove hot-path LINQ queries

Only one behavioral change of note would be in parsing exponents: I now allow '+' along with '-' for the sign character (for correctness).