### PR TITLE
Use TryParseExact instead of regex for date-time validation

### DIFF
--- a/Manatee.Json.Tests/Schema/StringSchemaTest.cs
+++ b/Manatee.Json.Tests/Schema/StringSchemaTest.cs
@@ -89,11 +89,11 @@ namespace Manatee.Json.Tests.Schema
 
 			results.AssertInvalid();
 		}
-		[Test]
-		public void ValidateReturnsValidOnValidDateTimeFormat()
+		[TestCaseSource(nameof(DateTimeCases))]
+		public void ValidateReturnsValidOnValidDateTimeFormat(string dateTimeString)
 		{
 			var schema = new JsonSchema().Type(JsonSchemaType.String).Format(StringFormat.DateTime);
-			var json = (JsonValue) "2016-01-25T10:32:02Z";
+			var json = (JsonValue) dateTimeString;
 
 			var results = schema.Validate(json);
 
@@ -302,5 +302,19 @@ namespace Manatee.Json.Tests.Schema
 
 			results.AssertValid();
 		}
+
+		private static string[] DateTimeCases = new[]
+		{
+			"2016-01-25T10:32:02Z",
+			"2019-06-25T08:40:24.1383719Z",
+			"2019-06-25T08:40:24.138371Z",
+			"2019-06-25T08:40:24.13837Z",
+			"2019-06-25T08:40:24.1383Z",
+			"2019-06-25T08:40:24.138Z",
+			"2019-06-25T08:40:24.13Z",
+			"2019-06-25T08:40:24.1Z",
+			"2019-06-26T15:46:18.4123654+01:00",
+			"2019-06-26T13:46:43.4281740-01:00"
+		};
 	}
 }

--- a/Manatee.Json/Schema/Keywords/StringFormat.cs
+++ b/Manatee.Json/Schema/Keywords/StringFormat.cs
@@ -1,5 +1,6 @@
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using JetBrains.Annotations;
 using Manatee.Json.Internal;
@@ -110,6 +111,19 @@ namespace Manatee.Json.Schema
 
 		internal bool IsKnown { get; private set; } = true;
 
+		private static string[] DateTimeFormats = new[]
+		{
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffffK",
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'ffffffK",
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffffK",
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'ffffK",
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fffK",
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'ffK",
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'fK",
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ssK",
+			"yyyy'-'MM'-'dd'T'HH':'mm':'ss",
+		};
+
 		static StringFormat()
 		{
 			_lookup = new Dictionary<string, StringFormat>();
@@ -117,7 +131,7 @@ namespace Manatee.Json.Schema
 			Date = new StringFormat("date", JsonSchemaVersion.Draft2019_06,
 			                        @"^(\d{4})-(\d{2})-(\d{2})$");
 			DateTime = new StringFormat("date-time", JsonSchemaVersion.All,
-										@"^(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\:(\d{2}(\.\d{1,6})?)([+-](\d{2})\:(\d{2})|Z)$");
+										s => System.DateTimeOffset.TryParseExact(s, DateTimeFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out _));
 			Duration = new StringFormat("duration", JsonSchemaVersion.Draft2019_06,
 			                            @"^(-?)P(?=\d|T\d)(?:(\d+)Y)?(?:(\d+)M)?(?:(\d+)([DW]))?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?)?$");
 			Email = new StringFormat("email", JsonSchemaVersion.All,


### PR DESCRIPTION
DateTimeOffset.TryParseExact is preferable over regex for validating date-time values because it will also check that the range of values is valid (i.e. February 30 is not a valid date).

Fixes #211 