### PR TITLE
New schema tests for ref

### DIFF
--- a/Manatee.Json/Internal/StringExtensions.cs
+++ b/Manatee.Json/Internal/StringExtensions.cs
@@ -206,5 +206,10 @@ namespace Manatee.Json.Internal
 				.Insert(0, s, n)
 				.ToString();
 		}
+
+		public static bool IsLocalSchemaId(this string s)
+		{
+			return s != "#" && !s.Contains("#/") && s.Contains("#");
+		}
 	}
 }

--- a/Manatee.Json/Manatee.Json.csproj
+++ b/Manatee.Json/Manatee.Json.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Provides an intuitive approach to JSON, including its structure, serialization, JSON Schema, JSON Path, JSON Pointer, and JSON Patch.</Description>
-    <Version>10.2.0-beta2</Version>
+    <Version>11.0.0-beta1</Version>
     <Copyright>Copyright © 2018 Little Crab Solutions</Copyright>
     <PackageLicenseUrl>https://github.com/gregsdennis/Manatee.Json/blob/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://gregsdennis.github.io/Manatee.Json/</PackageProjectUrl>
@@ -13,8 +13,8 @@
     <PackageReleaseNotes>See https://gregsdennis.github.io/Manatee.Json/release-notes.html</PackageReleaseNotes>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>Manatee.Json.snk</AssemblyOriginatorKeyFile>
-    <FileVersion>10.2.0.0</FileVersion>
-    <AssemblyVersion>10.0.0.0</AssemblyVersion>
+    <FileVersion>11.0.0.0</FileVersion>
+    <AssemblyVersion>11.0.0.0</AssemblyVersion>
     <Authors>gregsdennis</Authors>
     <Company>Little Crab Solutions</Company>
   </PropertyGroup>

--- a/Manatee.Json/Pointer/JsonPointer.cs
+++ b/Manatee.Json/Pointer/JsonPointer.cs
@@ -55,8 +55,10 @@ namespace Manatee.Json.Pointer
 
 			if (parts[0] == "#")
 				pointer._usesHash = true;
-			else
+			else if (string.IsNullOrEmpty(parts[0]))
 				parts = parts.Skip(1).ToArray();
+			else
+				parts = parts.ToArray();
 
 			pointer.AddRange(parts.SkipWhile(s => s == "#").Select(_Unescape));
 

--- a/Manatee.Json/Schema/JsonSchema.cs
+++ b/Manatee.Json/Schema/JsonSchema.cs
@@ -127,6 +127,7 @@ namespace Manatee.Json.Schema
 			else
 			{
 				var asJson = ToJson(new JsonSerializer());
+#pragma warning disable 618
 				var context = new SchemaValidationContext
 					{
 						Instance = asJson,
@@ -135,6 +136,7 @@ namespace Manatee.Json.Schema
 						InstanceLocation = new JsonPointer("#"),
 						IsMetaSchemaValidation = true
 					};
+#pragma warning restore 618
 				if (supportedVersions.HasFlag(JsonSchemaVersion.Draft04))
 				{
 					context.Root = MetaSchemas.Draft04;
@@ -189,14 +191,16 @@ namespace Manatee.Json.Schema
 		/// <returns>Results object containing a final result and any errors that may have been found.</returns>
 		public SchemaValidationResults Validate(JsonValue json)
 		{
+#pragma warning disable 618
 			var results = Validate(new SchemaValidationContext
-				{
+				                       {
 					Instance = json,
 					Root = this,
 					BaseRelativeLocation = new JsonPointer("#"),
 					RelativeLocation = new JsonPointer("#"),
 					InstanceLocation = new JsonPointer("#")
 				});
+#pragma warning restore 618
 
 			switch (JsonSchemaOptions.OutputFormat)
 			{
@@ -228,8 +232,12 @@ namespace Manatee.Json.Schema
 			if (_hasRegistered) return;
 			_hasRegistered = true;
 
-			if (Uri.TryCreate(Id, UriKind.Absolute, out var uri))
+			var address = Id;
+			if (baseUri != null && address != null)
+				address = new Uri(baseUri, address).OriginalString;
+			if (Uri.TryCreate(address, UriKind.Absolute, out var uri))
 			{
+				DocumentPath = uri;
 				JsonSchemaRegistry.Register(this);
 				baseUri = uri;
 			}
@@ -271,7 +279,6 @@ namespace Manatee.Json.Schema
 			var foundSchema = serializer.Deserialize<JsonSchema>(found.Result);
 
 			return foundSchema;
-
 		}
 
 		internal SchemaValidationResults Validate(SchemaValidationContext context)
@@ -287,6 +294,7 @@ namespace Manatee.Json.Schema
 			}
 
 			RegisterSubschemas(null);
+			context.LocalRegistry.RegisterLocal(this);
 
 			context.Local = this;
 

--- a/Manatee.Json/Schema/JsonSchema.cs
+++ b/Manatee.Json/Schema/JsonSchema.cs
@@ -127,7 +127,6 @@ namespace Manatee.Json.Schema
 			else
 			{
 				var asJson = ToJson(new JsonSerializer());
-#pragma warning disable 618
 				var context = new SchemaValidationContext
 					{
 						Instance = asJson,
@@ -136,7 +135,6 @@ namespace Manatee.Json.Schema
 						InstanceLocation = new JsonPointer("#"),
 						IsMetaSchemaValidation = true
 					};
-#pragma warning restore 618
 				if (supportedVersions.HasFlag(JsonSchemaVersion.Draft04))
 				{
 					context.Root = MetaSchemas.Draft04;
@@ -191,7 +189,6 @@ namespace Manatee.Json.Schema
 		/// <returns>Results object containing a final result and any errors that may have been found.</returns>
 		public SchemaValidationResults Validate(JsonValue json)
 		{
-#pragma warning disable 618
 			var results = Validate(new SchemaValidationContext
 				                       {
 					Instance = json,
@@ -200,7 +197,6 @@ namespace Manatee.Json.Schema
 					RelativeLocation = new JsonPointer("#"),
 					InstanceLocation = new JsonPointer("#")
 				});
-#pragma warning restore 618
 
 			switch (JsonSchemaOptions.OutputFormat)
 			{
@@ -227,10 +223,13 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			if (_hasRegistered) return;
 			_hasRegistered = true;
+
+			localRegistry.RegisterLocal(this);
 
 			var address = Id;
 			if (baseUri != null && address != null)
@@ -244,7 +243,7 @@ namespace Manatee.Json.Schema
 
 			foreach (var keyword in this)
 			{
-				keyword.RegisterSubschemas(baseUri);
+				keyword.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>
@@ -293,7 +292,7 @@ namespace Manatee.Json.Schema
 					};
 			}
 
-			RegisterSubschemas(null);
+			RegisterSubschemas(null, context.LocalRegistry);
 			context.LocalRegistry.RegisterLocal(this);
 
 			context.Local = this;

--- a/Manatee.Json/Schema/JsonSchema.cs
+++ b/Manatee.Json/Schema/JsonSchema.cs
@@ -190,7 +190,7 @@ namespace Manatee.Json.Schema
 		public SchemaValidationResults Validate(JsonValue json)
 		{
 			var results = Validate(new SchemaValidationContext
-				                       {
+				{
 					Instance = json,
 					Root = this,
 					BaseRelativeLocation = new JsonPointer("#"),

--- a/Manatee.Json/Schema/JsonSchemaRegistry.cs
+++ b/Manatee.Json/Schema/JsonSchemaRegistry.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using Manatee.Json.Internal;
 using Manatee.Json.Patch;
 using Manatee.Json.Serialization;
 
@@ -91,7 +92,7 @@ namespace Manatee.Json.Schema
 
 		internal void RegisterLocal(JsonSchema schema)
 		{
-			if (schema.Id == null) return;
+			if (schema.Id == null || !schema.Id.IsLocalSchemaId()) return;
 			lock (_contextLookup)
 			{
 				_contextLookup[schema.Id] = schema;

--- a/Manatee.Json/Schema/JsonSchemaRegistry.cs
+++ b/Manatee.Json/Schema/JsonSchemaRegistry.cs
@@ -8,10 +8,11 @@ namespace Manatee.Json.Schema
 	/// <summary>
 	/// Provides a registry in which JSON schema can be saved to be referenced by the system.
 	/// </summary>
-	public static class JsonSchemaRegistry
+	public class JsonSchemaRegistry
 	{
 		private static readonly ConcurrentDictionary<string, JsonSchema> _schemaLookup;
 		private static readonly JsonSerializer _serializer;
+		private readonly ConcurrentDictionary<string, JsonSchema> _contextLookup;
 
 		/// <summary>
 		/// Initializes the <see cref="JsonSchemaRegistry"/> class.
@@ -21,6 +22,10 @@ namespace Manatee.Json.Schema
 			_schemaLookup = new ConcurrentDictionary<string, JsonSchema>();
 			_serializer = new JsonSerializer();
 			Clear();
+		}
+		internal JsonSchemaRegistry()
+		{
+			_contextLookup = new ConcurrentDictionary<string, JsonSchema>();
 		}
 
 		/// <summary>
@@ -50,6 +55,28 @@ namespace Manatee.Json.Schema
 			return schema;
 		}
 
+		internal static JsonSchema GetWellKnown(string uri)
+		{
+			lock (_schemaLookup)
+			{
+				uri = uri.TrimEnd('#');
+				_schemaLookup.TryGetValue(uri, out var schema);
+
+				return schema;
+			}
+		}
+
+		internal JsonSchema GetLocal(string uri)
+		{
+			lock (_contextLookup)
+			{
+				uri = uri.TrimEnd('#');
+				_contextLookup.TryGetValue(uri, out var schema);
+
+				return schema;
+			}
+		}
+
 		/// <summary>
 		/// Explicitly registers an existing schema.
 		/// </summary>
@@ -59,6 +86,15 @@ namespace Manatee.Json.Schema
 			lock (_schemaLookup)
 			{
 				_schemaLookup[schema.DocumentPath.OriginalString] = schema;
+			}
+		}
+
+		internal void RegisterLocal(JsonSchema schema)
+		{
+			if (schema.Id == null) return;
+			lock (_contextLookup)
+			{
+				_contextLookup[schema.Id] = schema;
 			}
 		}
 

--- a/Manatee.Json/Schema/Keywords/AdditionalItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/AdditionalItemsKeyword.cs
@@ -94,17 +94,13 @@ namespace Manatee.Json.Schema
 					{
 						var baseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name);
 						var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
-						var newContext = new SchemaValidationContext
+						var newContext = new SchemaValidationContext(context)
 							{
-								BaseUri = context.BaseUri,
 								Instance = jv,
-								Root = context.Root,
-								RecursiveAnchor = context.RecursiveAnchor,
 								BaseRelativeLocation = baseRelativeLocation,
 								RelativeLocation = relativeLocation,
 								InstanceLocation = context.InstanceLocation.CloneAndAppend(i.ToString()),
-								IsMetaSchemaValidation = context.IsMetaSchemaValidation
-						};
+							};
 						var localResults = Value.Validate(newContext);
 						context.LastEvaluatedIndex = Math.Max(context.LastEvaluatedIndex, i);
 						context.LocalTierLastEvaluatedIndex = Math.Max(context.LastEvaluatedIndex, i);

--- a/Manatee.Json/Schema/Keywords/AdditionalItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/AdditionalItemsKeyword.cs
@@ -123,9 +123,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/AdditionalPropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/AdditionalPropertiesKeyword.cs
@@ -114,9 +114,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/AdditionalPropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/AdditionalPropertiesKeyword.cs
@@ -89,17 +89,13 @@ namespace Manatee.Json.Schema
 
 			foreach (var kvp in toEvaluate)
 			{
-				var newContext = new SchemaValidationContext
+				var newContext = new SchemaValidationContext(context)
 					{
-						BaseUri = context.BaseUri,
 						Instance = kvp.Value,
-						Root = context.Root,
-						RecursiveAnchor = context.RecursiveAnchor,
 						BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name),
 						RelativeLocation = context.RelativeLocation.CloneAndAppend(Name),
 						InstanceLocation = context.InstanceLocation.CloneAndAppend(kvp.Key),
-						IsMetaSchemaValidation = context.IsMetaSchemaValidation
-				};
+					};
 				nestedResults.Add(Value.Validate(newContext));
 			}
 

--- a/Manatee.Json/Schema/Keywords/AllOfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/AllOfKeyword.cs
@@ -50,17 +50,11 @@ namespace Manatee.Json.Schema
 		{
 			var nestedResults = this.Select((s, i) =>
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
-							Instance = context.Instance,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name, i.ToString()),
 							RelativeLocation = context.RelativeLocation.CloneAndAppend(Name, i.ToString()),
-							InstanceLocation = context.InstanceLocation,
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					var result = s.Validate(newContext);
 					context.EvaluatedPropertyNames.AddRange(newContext.EvaluatedPropertyNames);
 					context.EvaluatedPropertyNames.AddRange(newContext.LocallyEvaluatedPropertyNames);

--- a/Manatee.Json/Schema/Keywords/AllOfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/AllOfKeyword.cs
@@ -90,11 +90,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in this)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/AnyOfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/AnyOfKeyword.cs
@@ -48,17 +48,11 @@ namespace Manatee.Json.Schema
 		{
 			var nestedResults = this.Select((s, i) =>
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
-							Instance = context.Instance,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name, i.ToString()),
 							RelativeLocation = context.RelativeLocation.CloneAndAppend(Name, i.ToString()),
-							InstanceLocation = context.InstanceLocation,
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					var result = s.Validate(newContext);
 					context.EvaluatedPropertyNames.AddRange(newContext.EvaluatedPropertyNames);
 					context.EvaluatedPropertyNames.AddRange(newContext.LocallyEvaluatedPropertyNames);

--- a/Manatee.Json/Schema/Keywords/AnyOfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/AnyOfKeyword.cs
@@ -81,11 +81,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in this)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/CommentKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/CommentKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ConstKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ConstKeyword.cs
@@ -84,7 +84,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ContainsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ContainsKeyword.cs
@@ -73,17 +73,13 @@ namespace Manatee.Json.Schema
 			var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
 			var nestedResults = context.Instance.Array.Select((jv, i) =>
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
 							Instance = jv,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = baseRelativeLocation,
 							RelativeLocation = relativeLocation,
 							InstanceLocation = context.InstanceLocation.CloneAndAppend(i.ToString()),
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					var result = Value.Validate(newContext);
 					return result;
 				});

--- a/Manatee.Json/Schema/Keywords/ContainsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ContainsKeyword.cs
@@ -118,9 +118,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/ContentEncodingKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ContentEncodingKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ContentMediaTypeKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ContentMediaTypeKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ContentSchemaKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ContentSchemaKeyword.cs
@@ -59,17 +59,12 @@ namespace Manatee.Json.Schema
 
 			var baseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name);
 			var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
-			var nestedResult = Value.Validate(new SchemaValidationContext
+			var nestedResult = Value.Validate(new SchemaValidationContext(context)
 				{
-					BaseUri = context.BaseUri,
-					Instance = context.Instance,
-					Root = context.Root,
-					RecursiveAnchor = context.RecursiveAnchor,
 					BaseRelativeLocation = baseRelativeLocation,
 					RelativeLocation = relativeLocation,
 					InstanceLocation = context.InstanceLocation.CloneAndAppend(Name),
-					IsMetaSchemaValidation = context.IsMetaSchemaValidation
-			});
+				});
 
 			SchemaValidationResults results;
 			if (JsonSchemaOptions.OutputFormat == SchemaValidationOutputFormat.Flag &&

--- a/Manatee.Json/Schema/Keywords/ContentSchemaKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ContentSchemaKeyword.cs
@@ -85,9 +85,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/DefaultKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DefaultKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/DefsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DefsKeyword.cs
@@ -44,11 +44,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in Values)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/DependenciesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DependenciesKeyword.cs
@@ -91,11 +91,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in this)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/DependenciesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DependenciesKeyword.cs
@@ -52,17 +52,11 @@ namespace Manatee.Json.Schema
 			var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
 			var nestedResults = this.Select(d =>
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
-							Instance = context.Instance,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = baseRelativeLocation,
 							RelativeLocation = relativeLocation,
-							InstanceLocation = context.InstanceLocation,
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					return d.Validate(newContext);
 				});
 

--- a/Manatee.Json/Schema/Keywords/DependentRequiredKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DependentRequiredKeyword.cs
@@ -52,17 +52,11 @@ namespace Manatee.Json.Schema
 			var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
 			var nestedResults = this.Select(d =>
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
-							Instance = context.Instance,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = baseRelativeLocation,
 							RelativeLocation = relativeLocation,
-							InstanceLocation = context.InstanceLocation,
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					return d.Validate(newContext);
 				}).ToList();
 

--- a/Manatee.Json/Schema/Keywords/DependentRequiredKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DependentRequiredKeyword.cs
@@ -89,11 +89,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in this)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/DependentSchemasKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DependentSchemasKeyword.cs
@@ -52,17 +52,11 @@ namespace Manatee.Json.Schema
 			var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
 			var nestedResults = this.Select(d =>
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
-							Instance = context.Instance,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = baseRelativeLocation,
 							RelativeLocation = relativeLocation,
-							InstanceLocation = context.InstanceLocation,
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					return d.Validate(newContext);
 				}).ToList();
 

--- a/Manatee.Json/Schema/Keywords/DependentSchemasKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DependentSchemasKeyword.cs
@@ -89,11 +89,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in this)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/DeprecatedKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DeprecatedKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/DescriptionKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/DescriptionKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ElseKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ElseKeyword.cs
@@ -68,9 +68,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/EnumKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/EnumKeyword.cs
@@ -79,7 +79,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ExamplesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ExamplesKeyword.cs
@@ -62,7 +62,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ExclusiveMaximumDraft04Keyword.cs
+++ b/Manatee.Json/Schema/Keywords/ExclusiveMaximumDraft04Keyword.cs
@@ -90,7 +90,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ExclusiveMaximumKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ExclusiveMaximumKeyword.cs
@@ -86,7 +86,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ExclusiveMinimumDraft04Keyword.cs
+++ b/Manatee.Json/Schema/Keywords/ExclusiveMinimumDraft04Keyword.cs
@@ -90,7 +90,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ExclusiveMinimumKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ExclusiveMinimumKeyword.cs
@@ -86,7 +86,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/FormatKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/FormatKeyword.cs
@@ -90,7 +90,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/IJsonSchemaDependency.cs
+++ b/Manatee.Json/Schema/Keywords/IJsonSchemaDependency.cs
@@ -28,10 +28,11 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
 		/// <implementationNotes>
 		/// If the dependency does not contain any schemas (e.g. `maximum`), this method is a no-op.
 		/// </implementationNotes>
-		void RegisterSubschemas(Uri baseUri);
+		void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry);
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/IJsonSchemaKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/IJsonSchemaKeyword.cs
@@ -41,10 +41,11 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
 		/// <implementationNotes>
 		/// If the keyword does not contain any schemas (e.g. `maximum`), this method is a no-op.
 		/// </implementationNotes>
-		void RegisterSubschemas(Uri baseUri);
+		void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry);
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/IdKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/IdKeyword.cs
@@ -60,7 +60,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/IfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/IfKeyword.cs
@@ -116,9 +116,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/IfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/IfKeyword.cs
@@ -59,17 +59,11 @@ namespace Manatee.Json.Schema
 
 			if (then == null && @else == null) return SchemaValidationResults.Null;
 
-			var newContext = new SchemaValidationContext
+			var newContext = new SchemaValidationContext(context)
 				{
-					BaseUri = context.BaseUri,
-					Instance = context.Instance,
-					Root = context.Root,
-					RecursiveAnchor = context.RecursiveAnchor,
 					BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name),
 					RelativeLocation = context.RelativeLocation.CloneAndAppend(Name),
-					InstanceLocation = context.InstanceLocation,
-					IsMetaSchemaValidation = context.IsMetaSchemaValidation
-			};
+				};
 
 			var ifResults = Value.Validate(newContext);
 
@@ -79,17 +73,11 @@ namespace Manatee.Json.Schema
 
 				var results = new SchemaValidationResults(Name, context);
 
-				newContext = new SchemaValidationContext
+				newContext = new SchemaValidationContext(context)
 					{
-						BaseUri = context.BaseUri,
-						Instance = context.Instance,
-						Root = context.Root,
-						RecursiveAnchor = context.RecursiveAnchor,
 						BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(then.Name),
 						RelativeLocation = context.RelativeLocation.CloneAndAppend(then.Name),
-						InstanceLocation = context.InstanceLocation,
-						IsMetaSchemaValidation = context.IsMetaSchemaValidation
-				};
+					};
 				var thenResults = then.Value.Validate(newContext);
 				if (!thenResults.IsValid)
 				{
@@ -107,17 +95,11 @@ namespace Manatee.Json.Schema
 
 				var results = new SchemaValidationResults(Name, context);
 
-				newContext = new SchemaValidationContext
+				newContext = new SchemaValidationContext(context)
 					{
-						BaseUri = context.BaseUri,
-						Instance = context.Instance,
-						Root = context.Root,
-						RecursiveAnchor = context.RecursiveAnchor,
 						BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(@else.Name),
 						RelativeLocation = context.RelativeLocation.CloneAndAppend(@else.Name),
-						InstanceLocation = context.InstanceLocation,
-						IsMetaSchemaValidation = context.IsMetaSchemaValidation
-				};
+					};
 				var elseResults = @else.Value.Validate(newContext);
 				if (!elseResults.IsValid)
 				{

--- a/Manatee.Json/Schema/Keywords/ItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ItemsKeyword.cs
@@ -64,17 +64,13 @@ namespace Manatee.Json.Schema
 				var i = 0;
 				while (i < array.Count && i < Count)
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
 							Instance = array[i],
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name, i.ToString()),
 							RelativeLocation = context.RelativeLocation.CloneAndAppend(Name, i.ToString()),
 							InstanceLocation = context.InstanceLocation.CloneAndAppend(i.ToString()),
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					var localResults = this[i].Validate(newContext);
 					if (JsonSchemaOptions.OutputFormat == SchemaValidationOutputFormat.Flag && !localResults.IsValid)
 					{
@@ -97,16 +93,13 @@ namespace Manatee.Json.Schema
 				var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
 				var itemValidations = array.Select((jv, i) =>
 					{
-						var newContext = new SchemaValidationContext
+						var newContext = new SchemaValidationContext(context)
 							{
-								BaseUri = context.BaseUri,
 								Instance = jv,
-								Root = context.Root,
 								BaseRelativeLocation = baseRelativeLocation,
 								RelativeLocation = relativeLocation,
 								InstanceLocation = context.InstanceLocation.CloneAndAppend(i.ToString()),
-								IsMetaSchemaValidation = context.IsMetaSchemaValidation
-						};
+							};
 						var localResults = this[0].Validate(newContext);
 						context.LastEvaluatedIndex = Math.Max(context.LastEvaluatedIndex, i);
 						context.LocalTierLastEvaluatedIndex = Math.Max(context.LastEvaluatedIndex, i);

--- a/Manatee.Json/Schema/Keywords/ItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ItemsKeyword.cs
@@ -121,11 +121,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in this)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/MaxContainsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MaxContainsKeyword.cs
@@ -138,10 +138,11 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
+		/// <param name="localRegistry"></param>
 		/// <implementationNotes>
 		/// If the keyword does not contain any schemas (e.g. `maximum`), this method is a no-op.
 		/// </implementationNotes>
-		public void RegisterSubschemas(Uri baseUri) { }
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MaxItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MaxItemsKeyword.cs
@@ -83,7 +83,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MaxLengthKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MaxLengthKeyword.cs
@@ -85,7 +85,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MaxPropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MaxPropertiesKeyword.cs
@@ -83,7 +83,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MaximumKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MaximumKeyword.cs
@@ -83,7 +83,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MinContainsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MinContainsKeyword.cs
@@ -138,10 +138,11 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
+		/// <param name="localRegistry"></param>
 		/// <implementationNotes>
 		/// If the keyword does not contain any schemas (e.g. `maximum`), this method is a no-op.
 		/// </implementationNotes>
-		public void RegisterSubschemas(Uri baseUri) { }
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MinItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MinItemsKeyword.cs
@@ -83,7 +83,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MinLengthKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MinLengthKeyword.cs
@@ -85,7 +85,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MinPropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MinPropertiesKeyword.cs
@@ -83,7 +83,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MinimumKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MinimumKeyword.cs
@@ -83,7 +83,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/MultipleOfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/MultipleOfKeyword.cs
@@ -83,7 +83,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/NotKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/NotKeyword.cs
@@ -84,9 +84,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/NotKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/NotKeyword.cs
@@ -64,17 +64,11 @@ namespace Manatee.Json.Schema
 		{
 			var results = new SchemaValidationResults(Name, context);
 
-			var newContext = new SchemaValidationContext
+			var newContext = new SchemaValidationContext(context)
 				{
-					BaseUri = context.BaseUri,
-					Instance = context.Instance,
-					Root = context.Root,
-					RecursiveAnchor = context.RecursiveAnchor,
 					BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name),
 					RelativeLocation = context.RelativeLocation.CloneAndAppend(Name),
-					InstanceLocation = context.InstanceLocation,
-					IsMetaSchemaValidation = context.IsMetaSchemaValidation
-			};
+				};
 			var nestedResults = Value.Validate(newContext);
 			context.EvaluatedPropertyNames.AddRange(newContext.EvaluatedPropertyNames);
 			context.EvaluatedPropertyNames.AddRange(newContext.LocallyEvaluatedPropertyNames);

--- a/Manatee.Json/Schema/Keywords/OneOfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/OneOfKeyword.cs
@@ -49,17 +49,11 @@ namespace Manatee.Json.Schema
 		{
 			var nestedResults = this.Select((s, i) =>
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
-							Instance = context.Instance,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name, i.ToString()),
 							RelativeLocation = context.RelativeLocation.CloneAndAppend(Name, i.ToString()),
-							InstanceLocation = context.InstanceLocation,
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					var result = s.Validate(newContext);
 					context.EvaluatedPropertyNames.AddRange(newContext.EvaluatedPropertyNames);
 					context.EvaluatedPropertyNames.AddRange(newContext.LocallyEvaluatedPropertyNames);

--- a/Manatee.Json/Schema/Keywords/OneOfKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/OneOfKeyword.cs
@@ -104,11 +104,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in this)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/PatternKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/PatternKeyword.cs
@@ -91,7 +91,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/PatternPropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/PatternPropertiesKeyword.cs
@@ -65,17 +65,13 @@ namespace Manatee.Json.Schema
 				{
 					context.EvaluatedPropertyNames.Add(match);
 					context.LocallyEvaluatedPropertyNames.Add(match);
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
 							Instance = obj[match],
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = baseRelativeLocation,
 							RelativeLocation = relativeLocation,
 							InstanceLocation = context.InstanceLocation.CloneAndAppend(match),
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					var result = localSchema.Validate(newContext);
 					if (JsonSchemaOptions.OutputFormat == SchemaValidationOutputFormat.Flag && !result.IsValid)
 					{

--- a/Manatee.Json/Schema/Keywords/PatternPropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/PatternPropertiesKeyword.cs
@@ -94,11 +94,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in Values)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/PropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/PropertiesKeyword.cs
@@ -58,17 +58,13 @@ namespace Manatee.Json.Schema
 
 				context.EvaluatedPropertyNames.Add(property.Key);
 				context.LocallyEvaluatedPropertyNames.Add(property.Key);
-				var newContext = new SchemaValidationContext
+				var newContext = new SchemaValidationContext(context)
 					{
-						BaseUri = context.BaseUri,
 						Instance = obj[property.Key],
-						Root = context.Root,
-						RecursiveAnchor = context.RecursiveAnchor,
 						BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name, property.Key),
 						RelativeLocation = context.RelativeLocation.CloneAndAppend(Name, property.Key),
 						InstanceLocation = context.InstanceLocation.CloneAndAppend(property.Key),
-						IsMetaSchemaValidation = context.IsMetaSchemaValidation
-				};
+					};
 				var result = property.Value.Validate(newContext);
 				if (JsonSchemaOptions.OutputFormat == SchemaValidationOutputFormat.Flag && !result.IsValid)
 				{

--- a/Manatee.Json/Schema/Keywords/PropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/PropertiesKeyword.cs
@@ -86,11 +86,12 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
 			foreach (var schema in Values)
 			{
-				schema.RegisterSubschemas(baseUri);
+				schema.RegisterSubschemas(baseUri, localRegistry);
 			}
 		}
 		/// <summary>

--- a/Manatee.Json/Schema/Keywords/PropertyDependency.cs
+++ b/Manatee.Json/Schema/Keywords/PropertyDependency.cs
@@ -86,7 +86,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="locaRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry locaRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/PropertyNamesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/PropertyNamesKeyword.cs
@@ -72,17 +72,13 @@ namespace Manatee.Json.Schema
 			var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
 			var nestedResults = context.Instance.Object.Keys.Select(propertyName =>
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
 							Instance = propertyName,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = baseRelativeLocation,
 							RelativeLocation = relativeLocation,
 							InstanceLocation = context.InstanceLocation.CloneAndAppend(propertyName),
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					var result = Value.Validate(newContext);
 
 					return new {propertyName, result};

--- a/Manatee.Json/Schema/Keywords/PropertyNamesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/PropertyNamesKeyword.cs
@@ -104,9 +104,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/ReadOnlyKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ReadOnlyKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/RecursiveAnchorKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/RecursiveAnchorKeyword.cs
@@ -67,10 +67,11 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
+		/// <param name="localRegistry"></param>
 		/// <implementationNotes>
 		/// If the keyword does not contain any schemas (e.g. `maximum`), this method is a no-op.
 		/// </implementationNotes>
-		public void RegisterSubschemas(Uri baseUri) { }
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/RecursiveRefKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/RecursiveRefKeyword.cs
@@ -81,17 +81,13 @@ namespace Manatee.Json.Schema
 
 			var results = new SchemaValidationResults(Name, context);
 
-			var newContext = new SchemaValidationContext
+			var newContext = new SchemaValidationContext(context)
 				{
 					BaseUri = _resolvedRoot.DocumentPath,
-					Instance = context.Instance,
 					Root = _resolvedRoot ?? context.Root,
-					RecursiveAnchor = context.RecursiveAnchor,
 					BaseRelativeLocation = _resolvedFragment.WithHash(),
 					RelativeLocation = context.RelativeLocation.CloneAndAppend(Name),
-					InstanceLocation = context.InstanceLocation,
-					IsMetaSchemaValidation = context.IsMetaSchemaValidation
-			};
+				};
 
 			_validatingLocations.Add(context.InstanceLocation);
 			var nestedResults = Resolved.Validate(newContext);

--- a/Manatee.Json/Schema/Keywords/RefKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/RefKeyword.cs
@@ -74,7 +74,7 @@ namespace Manatee.Json.Schema
 
 			var newContext = new SchemaValidationContext(context)
 				{
-					BaseUri = _resolvedRoot.DocumentPath,
+					BaseUri = _resolvedRoot?.DocumentPath,
 					Instance = context.Instance,
 					Root = _resolvedRoot ?? context.Root,
 					BaseRelativeLocation = _resolvedFragment?.WithHash(),
@@ -91,7 +91,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>
@@ -155,7 +156,7 @@ namespace Manatee.Json.Schema
 
 		private void _ResolveReference(SchemaValidationContext context)
 		{
-			if (Reference != "#" && !Reference.StartsWith("#/") && Reference.StartsWith("#"))
+			if (Reference.IsLocalSchemaId())
 			{
 				Resolved = context.LocalRegistry.GetLocal(Reference);
 				if (Resolved != null) return;

--- a/Manatee.Json/Schema/Keywords/RefKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/RefKeyword.cs
@@ -72,17 +72,14 @@ namespace Manatee.Json.Schema
 
 			var results = new SchemaValidationResults(Name, context);
 
-			var newContext = new SchemaValidationContext
+			var newContext = new SchemaValidationContext(context)
 				{
 					BaseUri = _resolvedRoot.DocumentPath,
 					Instance = context.Instance,
 					Root = _resolvedRoot ?? context.Root,
-					RecursiveAnchor = context.RecursiveAnchor,
-					BaseRelativeLocation = _resolvedFragment.WithHash(),
+					BaseRelativeLocation = _resolvedFragment?.WithHash(),
 					RelativeLocation = context.RelativeLocation.CloneAndAppend(Name),
-					InstanceLocation = context.InstanceLocation,
-					IsMetaSchemaValidation = context.IsMetaSchemaValidation
-			};
+				};
 			var nestedResults = Resolved.Validate(newContext);
 
 			results.IsValid = nestedResults.IsValid;
@@ -158,6 +155,12 @@ namespace Manatee.Json.Schema
 
 		private void _ResolveReference(SchemaValidationContext context)
 		{
+			if (Reference != "#" && !Reference.StartsWith("#/") && Reference.StartsWith("#"))
+			{
+				Resolved = context.LocalRegistry.GetLocal(Reference);
+				if (Resolved != null) return;
+			}
+
 			var documentPath = context.BaseUri;
 			var referenceParts = Reference.Split(new[] { '#' }, StringSplitOptions.None);
 			var address = string.IsNullOrWhiteSpace(referenceParts[0]) ? documentPath?.OriginalString : referenceParts[0];
@@ -180,6 +183,13 @@ namespace Manatee.Json.Schema
 			}
 			else
 				_resolvedRoot = context.Root;
+
+			var wellKnown = JsonSchemaRegistry.GetWellKnown(Reference);
+			if (wellKnown != null)
+			{
+				Resolved = wellKnown;
+				return;
+			}
 
 			_ResolveLocalReference(_resolvedRoot?.DocumentPath ?? context.BaseUri);
 		}

--- a/Manatee.Json/Schema/Keywords/RequiredKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/RequiredKeyword.cs
@@ -97,7 +97,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/SchemaDependency.cs
+++ b/Manatee.Json/Schema/Keywords/SchemaDependency.cs
@@ -76,12 +76,13 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
+		/// <param name="localRegistry"></param>
 		/// <implementationNotes>
 		/// If the dependency does not contain any schemas (e.g. `maximum`), this method is a no-op.
 		/// </implementationNotes>
-		public void RegisterSubschemas(Uri baseUri)
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			_schema.RegisterSubschemas(baseUri);
+			_schema.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/SchemaDependency.cs
+++ b/Manatee.Json/Schema/Keywords/SchemaDependency.cs
@@ -54,15 +54,11 @@ namespace Manatee.Json.Schema
 			if (context.Instance.Type != JsonValueType.Object) return results;
 			if (!context.Instance.Object.ContainsKey(PropertyName)) return results;
 
-			var newContext = new SchemaValidationContext
+			var newContext = new SchemaValidationContext(context)
 				{
-					Instance = context.Instance,
-					Root = context.Root,
-					BaseUri = context.BaseUri,
 					BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(PropertyName),
 					RelativeLocation = context.RelativeLocation.CloneAndAppend(PropertyName),
-					InstanceLocation = context.InstanceLocation
-			};
+				};
 
 			var nestedResult = _schema.Validate(newContext);
 

--- a/Manatee.Json/Schema/Keywords/SchemaKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/SchemaKeyword.cs
@@ -60,7 +60,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/ThenKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/ThenKeyword.cs
@@ -68,9 +68,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/TitleKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/TitleKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/TypeKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/TypeKeyword.cs
@@ -114,7 +114,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/UnevaluatedItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/UnevaluatedItemsKeyword.cs
@@ -75,17 +75,13 @@ namespace Manatee.Json.Schema
 					{
 						var baseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name);
 						var relativeLocation = context.RelativeLocation.CloneAndAppend(Name);
-						var newContext = new SchemaValidationContext
+						var newContext = new SchemaValidationContext(context)
 							{
-								BaseUri = context.BaseUri,
 								Instance = jv,
-								Root = context.Root,
-								RecursiveAnchor = context.RecursiveAnchor,
 								BaseRelativeLocation = baseRelativeLocation,
 								RelativeLocation = relativeLocation,
 								InstanceLocation = context.InstanceLocation.CloneAndAppend(i.ToString()),
-								IsMetaSchemaValidation = context.IsMetaSchemaValidation
-						};
+							};
 						var localResults = Value.Validate(newContext);
 						context.LastEvaluatedIndex = Math.Max(context.LastEvaluatedIndex, i);
 						context.LocalTierLastEvaluatedIndex = Math.Max(context.LastEvaluatedIndex, i);

--- a/Manatee.Json/Schema/Keywords/UnevaluatedItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/UnevaluatedItemsKeyword.cs
@@ -118,9 +118,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/UnevaluatedPropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/UnevaluatedPropertiesKeyword.cs
@@ -73,17 +73,13 @@ namespace Manatee.Json.Schema
 
 			foreach (var kvp in toEvaluate)
 			{
-				var newContext = new SchemaValidationContext
+				var newContext = new SchemaValidationContext(context)
 					{
-						BaseUri = context.BaseUri,
 						Instance = kvp.Value,
-						Root = context.Root,
-						RecursiveAnchor = context.RecursiveAnchor,
 						BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name),
 						RelativeLocation = context.RelativeLocation.CloneAndAppend(Name),
 						InstanceLocation = context.InstanceLocation.CloneAndAppend(kvp.Key),
-						IsMetaSchemaValidation = context.IsMetaSchemaValidation
-				};
+					};
 				nestedResults.Add(Value.Validate(newContext));
 			}
 

--- a/Manatee.Json/Schema/Keywords/UnevaluatedPropertiesKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/UnevaluatedPropertiesKeyword.cs
@@ -112,9 +112,10 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri)
+		/// <param name="localRegistry">A local schema registry to handle cases where <paramref name="baseUri"/> is null.</param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)
 		{
-			Value.RegisterSubschemas(baseUri);
+			Value.RegisterSubschemas(baseUri, localRegistry);
 		}
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.

--- a/Manatee.Json/Schema/Keywords/UniqueItemsKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/UniqueItemsKeyword.cs
@@ -80,7 +80,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/VocabularyKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/VocabularyKeyword.cs
@@ -117,17 +117,11 @@ namespace Manatee.Json.Schema
 				var required = kvp.Value;
 				if (vocabulary.MetaSchemaId != null)
 				{
-					var newContext = new SchemaValidationContext
+					var newContext = new SchemaValidationContext(context)
 						{
-							BaseUri = context.BaseUri,
-							Instance = context.Instance,
-							Root = context.Root,
-							RecursiveAnchor = context.RecursiveAnchor,
 							BaseRelativeLocation = context.BaseRelativeLocation.CloneAndAppend(Name, vocabulary.Id),
 							RelativeLocation = context.RelativeLocation.CloneAndAppend(Name, vocabulary.Id),
-							InstanceLocation = context.InstanceLocation,
-							IsMetaSchemaValidation = context.IsMetaSchemaValidation
-					};
+						};
 					var metaSchema = JsonSchemaRegistry.Get(vocabulary.MetaSchemaId);
 					if (metaSchema != null)
 						metaSchema.Validate(newContext);

--- a/Manatee.Json/Schema/Keywords/VocabularyKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/VocabularyKeyword.cs
@@ -142,10 +142,11 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
+		/// <param name="localRegistry"></param>
 		/// <implementationNotes>
 		/// If the keyword does not contain any schemas (e.g. `maximum`), this method is a no-op.
 		/// </implementationNotes>
-		public void RegisterSubschemas(Uri baseUri) { }
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/Keywords/WriteOnlyKeyword.cs
+++ b/Manatee.Json/Schema/Keywords/WriteOnlyKeyword.cs
@@ -63,7 +63,8 @@ namespace Manatee.Json.Schema
 		/// Used register any subschemas during validation.  Enables look-forward compatibility with `$ref` keywords.
 		/// </summary>
 		/// <param name="baseUri">The current base URI</param>
-		public void RegisterSubschemas(Uri baseUri) { }
+		/// <param name="localRegistry"></param>
+		public void RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry) { }
 		/// <summary>
 		/// Resolves any subschemas during resolution of a `$ref` during validation.
 		/// </summary>

--- a/Manatee.Json/Schema/MetaSchemas.Draft08.cs
+++ b/Manatee.Json/Schema/MetaSchemas.Draft08.cs
@@ -7,8 +7,8 @@
 		/// </summary>
 		public static readonly JsonSchema Draft2019_06 =
 			new JsonSchema {SupportedVersions = JsonSchemaVersion.Draft2019_06}
-				.Schema("http://json-schema.org/2019-06/schema#")
-				.Id("http://json-schema.org/2019-06/schema#")
+				.Schema("http://json-schema.org/draft/2019-06/schema#")
+				.Id("http://json-schema.org/draft/2019-06/schema#")
 				.RecursiveAnchor(true)
 				.Vocabulary(SchemaVocabularies.Core, true)
 				.Vocabulary(SchemaVocabularies.Applicator, true)
@@ -43,8 +43,8 @@
 		/// </summary>
 		public static readonly JsonSchema Draft2019_06_Core =
 			new JsonSchema { SupportedVersions = JsonSchemaVersion.Draft2019_06 }
-				.Schema("http://json-schema.org/2019-06/schema#")
-				.Id("http://json-schema.org/2019-06/meta/core")
+				.Schema("http://json-schema.org/draft/2019-06/schema#")
+				.Id("http://json-schema.org/draft/2019-06/meta/core")
 				.Vocabulary(SchemaVocabularies.Core, true)
 				.RecursiveAnchor(true)
 				.Title("Core vocabulary meta-schema")
@@ -82,8 +82,8 @@
 		/// </summary>
 		public static readonly JsonSchema Draft2019_06_Applicator =
 			new JsonSchema {SupportedVersions = JsonSchemaVersion.Draft2019_06}
-				.Schema("http://json-schema.org/2019-06/schema#")
-				.Id("http://json-schema.org/2019-06/meta/applicator")
+				.Schema("http://json-schema.org/draft/2019-06/schema#")
+				.Id("http://json-schema.org/draft/2019-06/meta/applicator")
 				.Vocabulary(SchemaVocabularies.Applicator, true)
 				.RecursiveAnchor(true)
 				.Title("Applicator vocabulary meta-schema")
@@ -127,8 +127,8 @@
 		/// </summary>
 		public static readonly JsonSchema Draft2019_06_MetaData =
 			new JsonSchema {SupportedVersions = JsonSchemaVersion.Draft2019_06}
-				.Schema("http://json-schema.org/2019-06/schema#")
-				.Id("http://json-schema.org/2019-06/meta/meta-data")
+				.Schema("http://json-schema.org/draft/2019-06/schema#")
+				.Id("http://json-schema.org/draft/2019-06/meta/meta-data")
 				.Vocabulary(SchemaVocabularies.MetaData, true)
 				.RecursiveAnchor(true)
 				.Title("Meta-data vocabulary meta-schema")
@@ -150,8 +150,8 @@
 		/// </summary>
 		public static readonly JsonSchema Draft2019_06_Validation =
 			new JsonSchema {SupportedVersions = JsonSchemaVersion.Draft2019_06}
-				.Schema("http://json-schema.org/2019-06/schema#")
-				.Id("http://json-schema.org/2019-06/meta/validation")
+				.Schema("http://json-schema.org/draft/2019-06/schema#")
+				.Id("http://json-schema.org/draft/2019-06/meta/validation")
 				.Vocabulary(SchemaVocabularies.Validation, true)
 				.RecursiveAnchor(true)
 				.Title("Validation vocabulary meta-schema")
@@ -215,8 +215,8 @@
 		/// </summary>
 		public static readonly JsonSchema Draft2019_06_Format =
 			new JsonSchema {SupportedVersions = JsonSchemaVersion.Draft2019_06}
-				.Schema("http://json-schema.org/2019-06/schema#")
-				.Id("http://json-schema.org/2019-06/meta/format")
+				.Schema("http://json-schema.org/draft/2019-06/schema#")
+				.Id("http://json-schema.org/draft/2019-06/meta/format")
 				.Vocabulary(SchemaVocabularies.Format, true)
 				.RecursiveAnchor(true)
 				.Title("Format vocabulary meta-schema")
@@ -228,8 +228,8 @@
 		/// </summary>
 		public static readonly JsonSchema Draft2019_06_Content =
 			new JsonSchema {SupportedVersions = JsonSchemaVersion.Draft2019_06}
-				.Schema("http://json-schema.org/2019-06/schema#")
-				.Id("http://json-schema.org/2019-06/meta/content")
+				.Schema("http://json-schema.org/draft/2019-06/schema#")
+				.Id("http://json-schema.org/draft/2019-06/meta/content")
 				.Vocabulary(SchemaVocabularies.Content, true)
 				.RecursiveAnchor(true)
 				.Title("Content vocabulary meta-schema")

--- a/Manatee.Json/Schema/SchemaReferenceNotFoundException.cs
+++ b/Manatee.Json/Schema/SchemaReferenceNotFoundException.cs
@@ -18,7 +18,7 @@ namespace Manatee.Json.Schema
 		/// </summary>
 		/// <param name="location">The location of the reference relative to the original schema root.</param>
 		public SchemaReferenceNotFoundException(JsonPointer location)
-			: base($"Cannot resolve schema referenced by the pointer '{location}'.")
+			: base($"Cannot resolve schema referenced at '{location}'.")
 		{
 			Location = location;
 		}

--- a/Manatee.Json/Schema/SchemaValidationContext.cs
+++ b/Manatee.Json/Schema/SchemaValidationContext.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Manatee.Json.Pointer;
 
 namespace Manatee.Json.Schema
@@ -69,5 +70,40 @@ namespace Manatee.Json.Schema
 		/// processed in the correct order so that the communication occurs properly.
 		/// </remarks>
 		public Dictionary<string, object> Misc { get; } = new Dictionary<string, object>();
+
+		internal JsonSchemaRegistry LocalRegistry { get; }
+
+		/// <summary>
+		/// Obsolete - Creates a new instance of the <see cref="SchemaValidationContext"/> class.
+		/// </summary>
+		[Obsolete("Use the copy constructor instead and replace what you need.")]
+		public SchemaValidationContext()
+		{
+			LocalRegistry = new JsonSchemaRegistry();
+		}
+		/// <summary>
+		/// Creates a new instance of the <see cref="SchemaValidationContext"/> class by copying values from another instance.
+		/// </summary>
+		public SchemaValidationContext(SchemaValidationContext source)
+#pragma warning disable 618
+			: this()
+#pragma warning restore 618
+		{
+			Local = source.Local;
+			Root = source.Root;
+			RecursiveAnchor = source.RecursiveAnchor;
+			Instance = source.Instance;
+			EvaluatedPropertyNames.AddRange(source.EvaluatedPropertyNames);
+			LocallyEvaluatedPropertyNames.AddRange(source.LocallyEvaluatedPropertyNames);
+			LastEvaluatedIndex = source.LastEvaluatedIndex;
+			LocalTierLastEvaluatedIndex = source.LocalTierLastEvaluatedIndex;
+			BaseUri = source.BaseUri;
+			InstanceLocation = source.InstanceLocation;
+			RelativeLocation = source.RelativeLocation;
+			BaseRelativeLocation = source.BaseRelativeLocation;
+			IsMetaSchemaValidation = source.IsMetaSchemaValidation;
+
+			LocalRegistry = source.LocalRegistry;
+		}
 	}
 }

--- a/Manatee.Json/Schema/SchemaValidationContext.cs
+++ b/Manatee.Json/Schema/SchemaValidationContext.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using Manatee.Json.Pointer;
 
 namespace Manatee.Json.Schema
@@ -73,11 +72,7 @@ namespace Manatee.Json.Schema
 
 		internal JsonSchemaRegistry LocalRegistry { get; }
 
-		/// <summary>
-		/// Obsolete - Creates a new instance of the <see cref="SchemaValidationContext"/> class.
-		/// </summary>
-		[Obsolete("Use the copy constructor instead and replace what you need.")]
-		public SchemaValidationContext()
+		internal SchemaValidationContext()
 		{
 			LocalRegistry = new JsonSchemaRegistry();
 		}
@@ -85,9 +80,7 @@ namespace Manatee.Json.Schema
 		/// Creates a new instance of the <see cref="SchemaValidationContext"/> class by copying values from another instance.
 		/// </summary>
 		public SchemaValidationContext(SchemaValidationContext source)
-#pragma warning disable 618
 			: this()
-#pragma warning restore 618
 		{
 			Local = source.Local;
 			Root = source.Root;

--- a/Manatee.Json/Schema/SchemaValidationResults.cs
+++ b/Manatee.Json/Schema/SchemaValidationResults.cs
@@ -61,7 +61,7 @@ namespace Manatee.Json.Schema
 		internal SchemaValidationResults(SchemaValidationContext context)
 		{
 			InstanceLocation = context.InstanceLocation.Clone();
-			if (context.BaseUri != null)
+			if (context.BaseUri != null && context.BaseRelativeLocation != null)
 				AbsoluteLocation = new Uri(context.BaseUri + context.BaseRelativeLocation.ToString(), UriKind.RelativeOrAbsolute);
 			RelativeLocation = context.RelativeLocation;
 		}
@@ -73,7 +73,7 @@ namespace Manatee.Json.Schema
 		public SchemaValidationResults(string keyword, SchemaValidationContext context)
 		{
 			InstanceLocation = context.InstanceLocation.Clone();
-			if (context.BaseUri != null)
+			if (context.BaseUri != null && context.BaseRelativeLocation != null)
 				AbsoluteLocation = new Uri(context.BaseUri + context.BaseRelativeLocation.CloneAndAppend(keyword).ToString(), UriKind.RelativeOrAbsolute);
 			RelativeLocation = context.RelativeLocation.CloneAndAppend(keyword);
 			Keyword = keyword;

--- a/Manatee.Json/Schema/SchemaVocabularies.cs
+++ b/Manatee.Json/Schema/SchemaVocabularies.cs
@@ -12,26 +12,26 @@
 		/// <summary>
 		/// Identifies the 2019-06 core keywords vocabulary.
 		/// </summary>
-		public static readonly SchemaVocabulary Core = new SchemaVocabulary("http://json-schema.org/2019-06/vocab/core", "http://json-schema.org/2019-06/meta/core");
+		public static readonly SchemaVocabulary Core = new SchemaVocabulary("http://json-schema.org/draft/2019-06/vocab/core", "http://json-schema.org/draft/2019-06/meta/core");
 		/// <summary>
 		/// Identifies the 2019-06 applicator keywords vocabulary.
 		/// </summary>
-		public static readonly SchemaVocabulary Applicator = new SchemaVocabulary("http://json-schema.org/2019-06/vocab/applicator", "http://json-schema.org/2019-06/meta/applicator");
+		public static readonly SchemaVocabulary Applicator = new SchemaVocabulary("http://json-schema.org/draft/2019-06/vocab/applicator", "http://json-schema.org/draft/2019-06/meta/applicator");
 		/// <summary>
 		/// Identifies the 2019-06 meta-data keywords vocabulary.
 		/// </summary>
-		public static readonly SchemaVocabulary MetaData = new SchemaVocabulary("http://json-schema.org/2019-06/vocab/meta-data", "http://json-schema.org/2019-06/meta/meta-data");
+		public static readonly SchemaVocabulary MetaData = new SchemaVocabulary("http://json-schema.org/draft/2019-06/vocab/meta-data", "http://json-schema.org/draft/2019-06/meta/meta-data");
 		/// <summary>
 		/// Identifies the 2019-06 validation keywords vocabulary.
 		/// </summary>
-		public static readonly SchemaVocabulary Validation = new SchemaVocabulary("http://json-schema.org/2019-06/vocab/validation", "http://json-schema.org/2019-06/meta/validation");
+		public static readonly SchemaVocabulary Validation = new SchemaVocabulary("http://json-schema.org/draft/2019-06/vocab/validation", "http://json-schema.org/draft/2019-06/meta/validation");
 		/// <summary>
 		/// Identifies the 2019-06 format keywords vocabulary.
 		/// </summary>
-		public static readonly SchemaVocabulary Format = new SchemaVocabulary("http://json-schema.org/2019-06/vocab/format", "http://json-schema.org/2019-06/meta/format");
+		public static readonly SchemaVocabulary Format = new SchemaVocabulary("http://json-schema.org/draft/2019-06/vocab/format", "http://json-schema.org/draft/2019-06/meta/format");
 		/// <summary>
 		/// Identifies the 2019-06 content keywords vocabulary.
 		/// </summary>
-		public static readonly SchemaVocabulary Content = new SchemaVocabulary("http://json-schema.org/2019-06/vocab/content", "http://json-schema.org/2019-06/meta/content");
+		public static readonly SchemaVocabulary Content = new SchemaVocabulary("http://json-schema.org/draft/2019-06/vocab/content", "http://json-schema.org/draft/2019-06/meta/content");
 	}
 }

--- a/Manatee.Json/UriExtensions.cs
+++ b/Manatee.Json/UriExtensions.cs
@@ -20,7 +20,7 @@ namespace Manatee.Json
 		public static Uri GetParentUri(this Uri uri)
 		{
 			if (uri == null) throw new ArgumentNullException(nameof(uri));
-			if (!uri.IsAbsoluteUri && uri.Segments.Length == 1) throw new InvalidOperationException("Cannot get parent of root");
+			if (uri.IsAbsoluteUri && uri.Segments.Length == 1) throw new InvalidOperationException("Cannot get parent of root");
 
 			var path = uri.AbsoluteUri.Remove(uri.AbsoluteUri.Length - uri.Segments.Last().Length);
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ There are many ways to customize serialization.  See the wiki page for more deta
 
 Manatee.Json also:
 
-- Is covered by over 2000 unit tests
+- Is covered by over 3000 unit tests
 - Conforms to RFC-8259: The JSON specification
 - Supports:
     - .Net Framework 4.5

--- a/docs_source/release-notes.md
+++ b/docs_source/release-notes.md
@@ -1,12 +1,23 @@
-# 10.2.0
+# 11.0.0
 
-*Beta 1 - Released on 22 Jun, 2019*
+*v10.2.0 beta 1 - Released on 22 Jun, 2019*
 
-*Beta 2 - Released on 28 Jun, 2019*
+*v10.2.0 beta 2 - Released on 28 Jun, 2019*
+
+*v11.0.0 beta 1 - Released on 1 Jul, 2019*
 
 > ***NOTE** The properties for the new drafts contain version names like "Draft2019_06".  Since this depends on when the spec is released, these may change between the beta and the official release without incrementing the major version.*
 
 <span id="feature">feature</span>
+
+## Breaking changes
+
+In order to support some new independent reference tests, some changes were made to the schema validation logic to include a validation-run-independent schema registry, seperate from the static one.
+
+- `IJsonSchemaKeyword.RegisterSubschemas(Uri baseUri, JsonSchemaRegistry localRegistry)` - The second parameter is new.
+- `SchemaValidationContext` now requires a source context from which to copy values.
+
+## Non-breaking changes
 
 ([#175](https://github.com/gregsdennis/Manatee.Json/issues/175)) JSON Schema draft-08 support.  
 
@@ -17,6 +28,8 @@
 ([#201](https://github.com/gregsdennis/Manatee.Json/issues/201)) CompilerAttributes causes errors in .Net Standard versions.  This dependency has been removed.
 
 ([#211](https://github.com/gregsdennis/Manatee.Json/issues/211)) [@desmondgc](https://github.com/desmondgc) Date/Time format validation within schemas is insufficient.  Default implementation now uses `DateTime.TryParseExact()` with support for fractional seconds.
+
+- `JsonSchemaRegistry` is no longer static, but all previously existing functionality is still static.  All instance functionality is internal.
 
 # 10.1.4
 

--- a/docs_source/usage/schema/vocabs.md
+++ b/docs_source/usage/schema/vocabs.md
@@ -28,8 +28,9 @@ This is best explained with an example.  Suppose we have a meta-schema **M**, a 
     { "$ref": "https://json-schema.org/draft/2019-06/schema#" }
   ],
   "properties": {
-    "pastDate": {                                                           // 4
-      "type": "boolean"
+    "minDate": {                                                            // 4
+      "type": "string",
+      "format": "date"
     }
   }
 }
@@ -40,9 +41,7 @@ This is best explained with an example.  Suppose we have a meta-schema **M**, a 
   "$id": "https://myserver.net/schema#",
   "properties": {
     "publishedOnDate": {
-      "type": "string",
-      "format": "date",
-      "pastDate": true                                                      // 6
+      "minDate": "2019-01-01"                                               // 6
     }
   }
 }
@@ -53,22 +52,22 @@ This is best explained with an example.  Suppose we have a meta-schema **M**, a 
 }
 // instance I2
 {
-  "publishedOnDate": "2119-06-22"                                           // 8
+  "publishedOnDate": "1998-06-22"                                           // 8
 }
 ```
 
 1. We declare a meta-schema.  The meta-schema should validate itself, so we declare `$schema` to be the same as `$id`.
 2. We list the vocabularies that the Manatee.Json should know about in order to process schemas that declare this meta-schema as their `$schema` (see #5).  This includes all of the vocabularies from draft-08 (because we want all of the draft-08 capabilities) as well as the vocab for this meta-schema.  We'll explain a bit more about this later.
 3. We also need all of the syntactic validation from draft-08, so we include it in an `allOf`.
-4. We define a new keyword, `pastDate`, that takes a boolean value.
+4. We define a new keyword, `minDate`, that takes a date-formatted string value.
 5. We create a schema that uses our new meta-schema (because we want to use the new keyword).
 6. We use the new keyword to define a property to be found in the instance.
 7. The first instance defines a date in the past.
 8. The second date defines a date in the future.
 
-The kicker here is that we can read "pastDate" and know that when its value is `true`, the value of the property should be a date in the past... because we're human, and we understand things like that.  However, a validator isn't going to be able to infer that.  It can only validate that a boolean was given for `pastDate` in the schema (**S**).
+The kicker here is that we can read "minDate" and know that its value represents the minimum acceptable date... because we're human, and we understand things like that.  However, a validator isn't going to be able to infer that.  It can only validate that a date-formatted string was given for `minDate` in the schema (**S**).
 
-That's where the vocabulary comes in.  The vocabulary is a human-readable document that gives *semantic* meaning to `pastDate`.  It is documentation of business logic that allows a programmer to code an extension that provides additional validation.  For example, this is the documentation for `minLength` in the Schema Validation specification:
+That's where the vocabulary comes in.  The vocabulary is a human-readable document that gives *semantic* meaning to `minDate`.  It is documentation of business logic that allows a programmer to code an extension that provides additional validation.  For example, this is the documentation for `minLength` in the Schema Validation specification:
 
 > **6.3.2. minLength**
 >
@@ -82,11 +81,11 @@ That's where the vocabulary comes in.  The vocabulary is a human-readable docume
 
 It gives meaning to the keyword beyond how the meta-schema describes it: a non-negative integer.
 
-Any validator can validate that `pastDate` is a boolean, but only a validator that understands `https://myserver.net/my-vocab` as a vocabulary will understand that `pastDate` should validate that given a string that contains a date, that date should be in the past.
+Any validator can validate that `minDate` is a date-formatted string, but only a validator that understands `https://myserver.net/my-vocab` as a vocabulary will understand that `minDate` should validate that a date in the instance should be later than that in the schema.
 
-Now, if you look at the `$vocabulary` entry for `https://myserver.net/my-vocab`, the vocabulary has its ID as the key with a boolean value.  In this case, that value is `true`.  That means that if Manatee.Json *doesn't* know about the vocabulary, it **must** refuse to process any schema that declares **M** as its `$schema` (as **S** does).  If this value were `false`, then Manatee.Json would be allowed to continue, which means that only syntactic analysis (i.e. "Is `pastDate` a boolean?") would be performed.
+Now, if you look at the `$vocabulary` entry for `https://myserver.net/my-vocab`, the vocabulary has its ID as the key with a boolean value.  In this case, that value is `true`.  That means that if Manatee.Json *doesn't* know about the vocabulary, it **must** refuse to process any schema that declares **M** as its `$schema` (as **S** does).  If this value were `false`, then Manatee.Json would be allowed to continue, which means that only syntactic analysis (i.e. "Is `minDate` a date-formatted string?") would be performed.
 
-So, back to the example, because we declare the vocabulary to be required (by giving it a value of `true`) *and* because Manatee.Json knows about it, **I1** is reported as valid and **I2** is not.  If the vocabulary had not been required _and_ Manatee.Json didn't know about the vocabulary, both **I1** and **I2** would be reported as valid because the `pastDate` keyword would not have been enforced.
+So, back to the example, because we declare the vocabulary to be required (by giving it a value of `true`) *and* because Manatee.Json knows about it, **I1** is reported as valid and **I2** is not.  If the vocabulary had not been required _and_ Manatee.Json didn't know about the vocabulary, both **I1** and **I2** would be reported as valid because the `minDate` keyword would not have been enforced.
 
 ### Registering a vocabulary
 


### PR DESCRIPTION
The schema test suite was updated with some "independent ref" tests that define `$ref` targets that are not based on the location within the schema.

These tests were failing.  Sadly, the fix is a breaking change.... so here's v11