### PR TITLE
Slice.Find throws IndexOutOfRangeException if the index of the elemen…

### DIFF
--- a/Manatee.Json/Path/Slice.cs
+++ b/Manatee.Json/Path/Slice.cs
@@ -94,7 +94,7 @@ namespace Manatee.Json.Path
 		{
 			if (Index.HasValue)
 			{
-				return Index.Value < 0 || json.Count < Index.Value
+				return Index.Value < 0 || json.Count <= Index.Value
 						   ? Enumerable.Empty<JsonValue>()
 						   : new[] { json[Index.Value] };
 			}


### PR DESCRIPTION
…t is equal to the number of elements.

Reproduce:
`$.ArrayProperty[0]` on an empty array.