### PR TITLE
Fix JSON patch move, add operations & related tests.

### DIFF
--- a/Manatee.Json.Tests/Patch/TestSuite/JsonPatchTest.cs
+++ b/Manatee.Json.Tests/Patch/TestSuite/JsonPatchTest.cs
@@ -19,7 +19,7 @@ namespace Manatee.Json.Tests.Patch.TestSuite
 		public JsonValue ExpectedValue { get; set; }
 		public bool HasExpectedValue { get; set; }
 		public bool ExpectsError { get; set; }
-        public string Comment { get; set; }
+		public string Comment { get; set; }
 		public JsonPatch Patch { get; set; }
 		public bool Disabled { get; set; }
 		
@@ -28,13 +28,13 @@ namespace Manatee.Json.Tests.Patch.TestSuite
 			var obj = json.Object;
 			Comment = obj.TryGetString("comment");
 			Doc = obj["doc"];
-            if (obj.ContainsKey("expected"))
-            {
-                HasExpectedValue = true;
-                ExpectedValue = obj["expected"];
-            }
-            else
-                HasExpectedValue = false;
+			if (obj.ContainsKey("expected"))
+			{
+				HasExpectedValue = true;
+				ExpectedValue = obj["expected"];
+			}
+			else
+				HasExpectedValue = false;
 			ExpectsError = !string.IsNullOrWhiteSpace(obj.TryGetString("error"));
 			Patch = serializer.Deserialize<JsonPatch>(obj["patch"]);
 			Disabled = obj.TryGetBoolean("disabled") ?? false;

--- a/Manatee.Json.Tests/Patch/TestSuite/JsonPatchTest.cs
+++ b/Manatee.Json.Tests/Patch/TestSuite/JsonPatchTest.cs
@@ -19,7 +19,7 @@ namespace Manatee.Json.Tests.Patch.TestSuite
 		public JsonValue ExpectedValue { get; set; }
 		public bool HasExpectedValue { get; set; }
 		public bool ExpectsError { get; set; }
-		public string Comment { get; set; }
+        public string Comment { get; set; }
 		public JsonPatch Patch { get; set; }
 		public bool Disabled { get; set; }
 		
@@ -28,10 +28,13 @@ namespace Manatee.Json.Tests.Patch.TestSuite
 			var obj = json.Object;
 			Comment = obj.TryGetString("comment");
 			Doc = obj["doc"];
-			if (obj.ContainsKey("expected"))
-				ExpectedValue = obj["expected"];
-			else
-				HasExpectedValue = false;
+            if (obj.ContainsKey("expected"))
+            {
+                HasExpectedValue = true;
+                ExpectedValue = obj["expected"];
+            }
+            else
+                HasExpectedValue = false;
 			ExpectsError = !string.IsNullOrWhiteSpace(obj.TryGetString("error"));
 			Patch = serializer.Deserialize<JsonPatch>(obj["patch"]);
 			Disabled = obj.TryGetBoolean("disabled") ?? false;

--- a/Manatee.Json.Tests/Patch/TestSuite/JsonPatchTestSuite.cs
+++ b/Manatee.Json.Tests/Patch/TestSuite/JsonPatchTestSuite.cs
@@ -34,9 +34,8 @@ namespace Manatee.Json.Tests.Patch.TestSuite
 				{
 					var testDescription = test.Object.TryGetString("comment") ?? "UNNAMED TEST";
 					var testName = testDescription.Replace(' ', '_');
-                    
-                    yield return new TestCaseData(fileName, test) { TestName = testName };
-                }
+					yield return new TestCaseData(fileName, test) { TestName = testName };
+				}
 			}
 
 			JsonOptions.DuplicateKeyBehavior = DuplicateKeyBehavior.Throw;
@@ -74,8 +73,8 @@ namespace Manatee.Json.Tests.Patch.TestSuite
 
 					Assert.AreNotEqual(test.ExpectsError, result.Success);
 
-                    if (test.HasExpectedValue)
-					    Assert.AreEqual(test.ExpectedValue, result.Patched);
+					if (test.HasExpectedValue)
+						Assert.AreEqual(test.ExpectedValue, result.Patched);
 				}
 				catch (Exception e)
 				{

--- a/Manatee.Json.Tests/Patch/TestSuite/JsonPatchTestSuite.cs
+++ b/Manatee.Json.Tests/Patch/TestSuite/JsonPatchTestSuite.cs
@@ -34,8 +34,9 @@ namespace Manatee.Json.Tests.Patch.TestSuite
 				{
 					var testDescription = test.Object.TryGetString("comment") ?? "UNNAMED TEST";
 					var testName = testDescription.Replace(' ', '_');
-					yield return new TestCaseData(fileName, test) {TestName = testName};
-				}
+                    
+                    yield return new TestCaseData(fileName, test) { TestName = testName };
+                }
 			}
 
 			JsonOptions.DuplicateKeyBehavior = DuplicateKeyBehavior.Throw;
@@ -72,8 +73,9 @@ namespace Manatee.Json.Tests.Patch.TestSuite
 					result = test.Patch.TryApply(test.Doc);
 
 					Assert.AreNotEqual(test.ExpectsError, result.Success);
-					if (test.HasExpectedValue)
-						Assert.AreEqual(test.ExpectedValue, result.Patched);
+
+                    if (test.HasExpectedValue)
+					    Assert.AreEqual(test.ExpectedValue, result.Patched);
 				}
 				catch (Exception e)
 				{

--- a/Manatee.Json/Patch/JsonPatchAction.cs
+++ b/Manatee.Json/Patch/JsonPatchAction.cs
@@ -85,8 +85,8 @@ namespace Manatee.Json.Patch
 
 		private JsonPatchResult _Remove(JsonValue json)
 		{
-            return _RemoveAtPath(json, Path);
-        }
+			return _RemoveAtPath(json, Path);
+		}
 
 		private JsonPatchResult _Replace(JsonValue json)
 		{
@@ -98,16 +98,16 @@ namespace Manatee.Json.Patch
 		private JsonPatchResult _Move(JsonValue json)
 		{
 			// TODO: This isn't the most efficient way to do this, but it'll get the job done.
-            if(JsonPointer.Parse(From).Equals(JsonPointer.Parse(Path)))
-            {
-                return new JsonPatchResult(json);
-            }
+			if(JsonPointer.Parse(From).Equals(JsonPointer.Parse(Path)))
+			{
+				return new JsonPatchResult(json);
+			}
 
 			var copy = _Copy(json);
 			return !copy.Success ? copy : _RemoveAtPath(json, From);
 		}
 
-        private JsonPatchResult _Copy(JsonValue json)
+		private JsonPatchResult _Copy(JsonValue json)
 		{
 			var results = JsonPointer.Parse(From).Evaluate(json);
 			if (results.Error != null) return new JsonPatchResult(json, results.Error);
@@ -128,30 +128,30 @@ namespace Manatee.Json.Patch
 			return new JsonPatchResult(json);
 		}
 
-        private JsonPatchResult _RemoveAtPath(JsonValue json, string path)
-        {
-            if (string.IsNullOrEmpty(Path))
-            {
-                json.Object.Clear();
-                return new JsonPatchResult(json);
-            }
+		private JsonPatchResult _RemoveAtPath(JsonValue json, string path)
+		{
+			if (string.IsNullOrEmpty(Path))
+			{
+				json.Object.Clear();
+				return new JsonPatchResult(json);
+			}
 
-            var (target, key, index, found) = JsonPointerFunctions.ResolvePointer(json, path);
-            if (!found) return new JsonPatchResult(json, $"Path '{path}' not found.");
+			var (target, key, index, found) = JsonPointerFunctions.ResolvePointer(json, path);
+			if (!found) return new JsonPatchResult(json, $"Path '{path}' not found.");
 
-            switch (target.Type)
-            {
-                case JsonValueType.Object:
-                    target.Object.Remove(key);
-                    break;
-                case JsonValueType.Array:
-                    target.Array.RemoveAt(index);
-                    break;
-                default:
-                    return new JsonPatchResult(json, $"Cannot remove a value from a '{target.Type}'");
-            }
+			switch (target.Type)
+			{
+				case JsonValueType.Object:
+					target.Object.Remove(key);
+					break;
+				case JsonValueType.Array:
+					target.Array.RemoveAt(index);
+					break;
+				default:
+					return new JsonPatchResult(json, $"Cannot remove a value from a '{target.Type}'");
+			}
 
-            return new JsonPatchResult(json);
-        }
-    }
+			return new JsonPatchResult(json);
+		}
+	}
 }

--- a/Manatee.Json/Patch/JsonPointerFunctions.cs
+++ b/Manatee.Json/Patch/JsonPointerFunctions.cs
@@ -46,7 +46,7 @@ namespace Manatee.Json.Patch
             return (parent, key, index, true);
         }
 
-        public static (JsonValue result, bool success) InsertValue(JsonValue json, string path, JsonValue value)
+        public static (JsonValue result, bool success) InsertValue(JsonValue json, string path, JsonValue value, bool insertAfter)
         {
             if (path == string.Empty) return (value, true);
             var parts = path.Split('/').Skip(1);
@@ -81,13 +81,32 @@ namespace Manatee.Json.Patch
                         index = Math.Max(0, current.Array.Count - 1);
 
                     var array = current.Array;
-                    var tempIndex = index;
-                    addValue = v =>
+                    if (key == "-" || index == current.Array.Count)
+                    {
+                        addValue = v =>
                         {
-                            if (tempIndex > array.Count) return false;
-                            array.Insert(tempIndex, v);
+                            array.Add(v);
                             return true;
                         };
+                    }
+                    else
+                    {
+                        var tempIndex = index;
+                        addValue = v =>
+                            {
+                                if (tempIndex > array.Count - 1) return false;
+                                array.Insert(tempIndex, v);
+
+                                if (insertAfter)
+                                {
+                                    var oldValue = array[tempIndex];
+                                    array[tempIndex] = array[tempIndex + 1];
+                                    array[tempIndex + 1] = oldValue;
+                                }
+
+                                return true;
+                            };
+                    }
 
                     current = index < current.Array.Count
                                   ? current.Array[index]


### PR DESCRIPTION
Current implementation of JSON Patch doesn't follow [RFC6902](https://tools.ietf.org/html/rfc6902). NUnit do not do assert statements because conditions are wrong.

I fixed this stuff in PR. 

- Move operation works (this time correct object is removed after copy ;))
- Add and Insert operations are fixed (add is a different thing than insert in .net)
- Unit tests pass.

Code for patching still needs some fixes, maybe I'll find some time later to tweak things up.