### PR TITLE
Use Environment.NewLine in AppendIndentedString

### DIFF
--- a/Manatee.Json.Tests/JsonValueToStringTest.cs
+++ b/Manatee.Json.Tests/JsonValueToStringTest.cs
@@ -143,7 +143,7 @@ namespace Manatee.Json.Tests
 		public void GetIndentedString_Object_ReturnsCorrectIndention()
 		{
 			var json = new JsonValue(new JsonObject { { "bool", false }, { "int", 42 }, { "string", "a string" } });
-			var expected = "{\n\t\"bool\" : false,\n\t\"int\" : 42,\n\t\"string\" : \"a string\"\n}";
+			var expected = "{\r\n\t\"bool\" : false,\r\n\t\"int\" : 42,\r\n\t\"string\" : \"a string\"\r\n}";
 			var actual = json.GetIndentedString();
 			Assert.AreEqual(expected, actual);
 		}

--- a/Manatee.Json/JsonObject.cs
+++ b/Manatee.Json/JsonObject.cs
@@ -61,12 +61,16 @@ namespace Manatee.Json
 			string tab0 = JsonOptions.PrettyPrintIndent.Repeat(indentLevel),
 			       tab1 = tab0 + JsonOptions.PrettyPrintIndent;
 
-			builder.Append("{\n");
+			builder.Append("{");
+			builder.Append(Environment.NewLine);
 			bool comma = false;
 			foreach (var kvp in this)
 			{
 				if (comma)
-					builder.Append(",\n");
+				{
+					builder.Append(",");
+					builder.Append(Environment.NewLine);
+				}
 
 				builder.Append(tab1);
 				builder.Append('"');
@@ -76,7 +80,7 @@ namespace Manatee.Json
 
 				comma = true;
 			}
-			builder.Append('\n');
+			builder.Append(Environment.NewLine);
 			builder.Append(tab0);
 			builder.Append('}');
 		}


### PR DESCRIPTION
Replace assumption of \n with a different assumption...

This behavior could be perhaps stored in `JsonOptions`, similar to `JsonOptions.PrettyPrintIndent` as someone may want a specific line-ending instead of their system standard.